### PR TITLE
Fix installation for out-of-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,5 +14,5 @@ add_subdirectory(renderers)
 add_executable( uxplay uxplay.cpp)
 target_link_libraries ( uxplay renderers airplay )
 
-install(PROGRAMS uxplay DESTINATION bin)
+install(TARGETS uxplay DESTINATION bin)
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,27 @@
+# UxPlay
+
 This project is an early stage prototype of unix AirPlay server.
 Work is based on https://github.com/FD-/RPiPlay.
 Tested on Ubuntu 19.10 desktop.
 5G Wifi connection is the must.
 
-Features:
+## Features
 1. Based on Gstreamer.
 1. Video and audio are supported out of the box.
 3. Gstreamer decoding is plugin agnostic. Uses accelerated decoders if availible. VAAPI is preferable.
 4. Automatic screen orientation.
 
-Building:
-1. sudo apt-get install cmake
-2. sudo apt-get install libssl-dev libavahi-compat-libdnssd-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-libav
-3. sudo apt-get install gstreamer1.0-vaapi (For Intel graphics)
-4. mkdir build
-5. cd build
-6. cmake ..
-7. make
+## Building
+```bash
+sudo apt-get install cmake
+sudo apt-get install libssl-dev libavahi-compat-libdnssd-dev \
+                     libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+                     gstreamer1.0-libav
+sudo apt-get install gstreamer1.0-vaapi # For Intel graphics
+mkdir build
+cd build
+cmake ..
+# Alternatively (for higher optimization level and/or installation):
+# cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=path/to/install/dir
+make
+```


### PR DESCRIPTION
Fixes #12. Also applies some reformatting to the README for easier copy-pasting of the build instructions (but I can also take this out again).

@antimof Thanks a lot for this great tool: it works as advertised and out-of-the-box on Ubuntu 20.04!