### PR TITLE
Set _NET_WM_NAME so that the window can be shared on screen-sharing software

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(uxplay)
 
 set (CMAKE_CXX_STANDARD 11)
 
+find_package(X11 REQUIRED)
+link_libraries(${X11_LIBRARIES})
+include_directories(${X11_INCLUDE_DIR})
+# link_directories(${X11_LIBRARIES})
+
 add_subdirectory(lib/curve25519)
 add_subdirectory(lib/ed25519)
 add_subdirectory(lib/playfair)
@@ -12,7 +17,7 @@ add_subdirectory(lib)
 add_subdirectory(renderers)
 
 add_executable( uxplay uxplay.cpp)
-target_link_libraries ( uxplay renderers airplay )
+target_link_libraries ( uxplay renderers airplay ${X11_LIBRARIES})
 
 install(PROGRAMS uxplay DESTINATION bin)
 

--- a/renderers/video_renderer_gstreamer.c
+++ b/renderers/video_renderer_gstreamer.c
@@ -21,6 +21,13 @@
 #include <assert.h>
 #include <gst/gst.h>
 #include <gst/app/gstappsrc.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <stdio.h>
+
+Display* display;
+Window root, my_window;
+const char* application_name = "UXPLAY";
 
 struct video_renderer_s {
     logger_t *logger;
@@ -49,7 +56,38 @@ static gboolean check_plugins (void)
   return ret;
 }
 
+Window enum_windows(Display* display, Window window, int depth) {
+  int i;
+
+  XTextProperty text;
+  XGetWMName(display, window, &text);
+  char* name;
+  XFetchName(display, window, &name);
+
+  if (name != 0 && strcmp(application_name, name) == 0) {
+	return window;
+  }
+
+  Window _root, parent;
+  Window* children;
+  int n;
+  XQueryTree(display, window, &_root, &parent, &children, &n);
+  if (children != NULL) {
+    for (i = 0; i < n; i++) {
+      Window w = enum_windows(display, children[i], depth + 1);
+      if (w != NULL) return w;
+    }
+    XFree(children);
+  }
+
+  return NULL;
+}
+
+
 video_renderer_t *video_renderer_init(logger_t *logger, background_mode_t background_mode, bool low_latency) {
+    display = XOpenDisplay(NULL);
+    root = XDefaultRootWindow(display);
+
     video_renderer_t *renderer;
     GError *error = NULL;
 
@@ -57,6 +95,7 @@ video_renderer_t *video_renderer_init(logger_t *logger, background_mode_t backgr
     assert(renderer);
 
     gst_init(NULL, NULL);
+    g_set_application_name(application_name);
 
     renderer->logger = logger;
     
@@ -88,10 +127,20 @@ void video_renderer_render_buffer(video_renderer_t *renderer, raop_ntp_t *ntp, u
     GST_BUFFER_DTS(buffer) = (GstClockTime)pts;
     gst_buffer_fill(buffer, 0, data, data_len);
     gst_app_src_push_buffer (GST_APP_SRC(renderer->appsrc), buffer);
+
+    if (my_window == NULL) {
+	    my_window = enum_windows(display, root, 0);
+	    if (my_window != NULL) {
+		    char* str = "NEW NAME";
+		    Atom _NET_WM_NAME = XInternAtom(display, "_NET_WM_NAME", 0);
+		    Atom UTF8_STRING = XInternAtom(display, "UTF8_STRING", 0);
+		    XChangeProperty(display, my_window, _NET_WM_NAME, UTF8_STRING, 8, 0, str, strlen(str));
+		    XSync(display, False);
+	    }
+    }
 }
 
 void video_renderer_flush(video_renderer_t *renderer) {
-
 }
 
 void video_renderer_destroy(video_renderer_t *renderer) {
@@ -104,5 +153,4 @@ void video_renderer_destroy(video_renderer_t *renderer) {
 }
 
 void video_renderer_update_background(video_renderer_t *renderer, int type) {
-
 }

--- a/renderers/video_renderer_gstreamer.c
+++ b/renderers/video_renderer_gstreamer.c
@@ -131,7 +131,7 @@ void video_renderer_render_buffer(video_renderer_t *renderer, raop_ntp_t *ntp, u
     if (my_window == NULL) {
 	    my_window = enum_windows(display, root, 0);
 	    if (my_window != NULL) {
-		    char* str = "NEW NAME";
+		    char* str = "UxPlay";
 		    Atom _NET_WM_NAME = XInternAtom(display, "_NET_WM_NAME", 0);
 		    Atom UTF8_STRING = XInternAtom(display, "UTF8_STRING", 0);
 		    XChangeProperty(display, my_window, _NET_WM_NAME, UTF8_STRING, 8, 0, str, strlen(str));


### PR DESCRIPTION
Gstreamer does not set the _NET_WM_NAME property on the window it
creates when using `autovideosink` (or ximagesink/xvimagesink for that
matter).

A lot of tools (like Zoom) filter based on this field being non-null, so
the window can't be shared.

This horrible hack finds the first open window that matches our application
name and proceeds to set _NET_WM_NAME on it.

It is very ugly, and I do not know what I am doing, but it works. Feel free to use this to write something that makes more sense.