### PR TITLE
UxPlay 1.54:  minor fixes and add support for "cover art" display in audio-only ALAC mode

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,6 +1,7 @@
 <h1
-id="uxplay-1.53-airplayairplay-mirror-server-for-linux-macos-and-unix.">UxPlay
-1.53: AirPlay/AirPlay-Mirror server for Linux, macOS, and Unix.</h1>
+id="uxplay-1.54-airplay-mirror-and-airplay-audio-server-for-linux-macos-and-unix.">UxPlay
+1.54: AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and
+Unix.</h1>
 <h3
 id="now-developed-at-the-github-site-httpsgithub.comfdh2uxplay-where-all-user-issues-should-be-posted.">Now
 developed at the GitHub site <a
@@ -9,9 +10,10 @@ href="https://github.com/FDH2/UxPlay">https://github.com/FDH2/UxPlay</a>
 <p>Highlights:</p>
 <ul>
 <li>GPLv3, open source.</li>
-<li>Support for both AirPlay Mirror and AirPlay Audio-only (Apple
-Lossless ALAC) streaming protocols from current iOS/iPadOS 15.5
-clients.</li>
+<li>Originally supported only AirPlay Mirror protocol, now has added
+support for AirPlay Audio-only (Apple Lossless ALAC) streaming from
+current iOS/iPadOS 15.5 clients. <strong>There is no support for
+Airplay2 video-streaming protocol, and none is planned.</strong></li>
 <li>macOS computers (2011 or later, both Intel and “Apple Silicon” M1
 systems) can act either as AirPlay clients, or as the server running
 UxPlay. Using AirPlay, UxPlay can emulate a second display for macOS
@@ -25,9 +27,9 @@ to select different hardware-appropriate output “videosinks” and
 pipeline).</li>
 <li>Support for server behind a firewall.</li>
 <li><strong>New</strong>: Support for Raspberry Pi, with hardware video
-acceleration using Video4Linux2 (which supports both 32- and 64-bit
-systems, unlike deprecated OpenMAX (omx), which it replaces). (For
-GStreamer &lt; 1.22, a <a
+acceleration using Video4Linux2 (vl42), which supports both 32- and
+64-bit systems, unlike deprecated OpenMAX (omx), which is being dropped
+by RPi distributions in favor of v4l2. (For GStreamer &lt; 1.22, a <a
 href="https://github.com/FDH2/UxPlay/wiki/Gstreamer-Video4Linux2-plugin-patches">patch</a>
 to the GStreamer Video4Linux2 plugin, available in the <a
 href="https://github.com/FDH2/UxPlay/wiki">UxPlay Wiki</a>, is required,
@@ -38,9 +40,9 @@ reports</a>.</li>
 </ul>
 <p>This project is a GPLv3 open source unix AirPlay2 Mirror server for
 Linux, macOS, and *BSD. It was initially developed by <a
-href="http://github.com/antimof/Uxplay">antimof</a> using code from <a
-href="https://github.com/FD-/RPiPlay">RPiPlay</a>, which in turn derives
-from <a
+href="http://github.com/antimof/Uxplay">antimof</a> using code from
+OpenMAX-based <a href="https://github.com/FD-/RPiPlay">RPiPlay</a>,
+which in turn derives from <a
 href="https://github.com/KqsMea8/AirplayServer">AirplayServer</a>, <a
 href="https://github.com/juhovh/shairplay">shairplay</a>, and <a
 href="https://github.com/EstebanKubata/playfair">playfair</a>. (The
@@ -57,9 +59,10 @@ FreeBSD 13.1. On Raspberry Pi, it is tested on Raspberry Pi OS
 audio) of iOS/iPadOS/macOS clients (iPhones, iPads, MacBooks) in a
 window on the server display (with the possibility of sharing that
 window on screen-sharing applications such as Zoom) on a host running
-Linux, macOS, or other unix. UxPlay supports Apple’s AirPlay 2 protocol
+Linux, macOS, or other unix. UxPlay supports Apple’s AirPlay2 protocol
 using “Legacy Pairing”, but some features are missing. (Details of what
 is publically known about Apple’s AirPlay 2 protocol can be found <a
+href="https://openairplay.github.io/airplay-spec/">here</a>, <a
 href="https://github.com/SteeBono/airplayreceiver/wiki/AirPlay2-Protocol">here</a>
 and <a href="https://emanuelecozzi.net/docs/airplay2">here</a>).</p>
 <p>The UxPlay server and its client must be on the same local area
@@ -72,21 +75,35 @@ the avahi-daemon service, and is included in most Linux distributions
 (this service can also be provided by macOS, iOS or Windows
 servers).</p>
 <p>Connections to the UxPlay server by iOS/MacOS clients can be
-initiated both in AirPlay Mirror mode (which streams lossily-compressed
-AAC audio while mirroring the client screen, or in the alternative
-AirPlay Audio mode which streams Apple Lossless (ALAC) audio without
-screen mirroring (the accompanying cover art in this mode is not
-displayed, but metadata is displayed in the terminal). <em>Switching
-between these two modes during an active connection is possible: in
-Mirror mode, close the mirror window and start an Audio mode connection,
-switch back by initiating a Mirror mode connection.</em></p>
+initiated both in <strong>AirPlay Mirror</strong> mode (which streams
+lossily-compressed AAC audio while mirroring the client screen, or in
+the alternative <strong>AirPlay Audio</strong> mode which streams Apple
+Lossless (ALAC) audio without screen mirroring. In
+<strong>Audio</strong> mode, metadata is displayed in the uxplay
+terminal; if UxPlay option <code>-ca &lt;name&gt;</code> is used, the
+accompanying cover art is also output to a periodically-updated file
+<code>&lt;name&gt;</code>, and can be viewed with a (reloading) graphics
+viewer of your choice such as <code>feh</code>: run
+“<code>uxplay -ca &lt;name&gt; &amp;</code>” in the background, then run
+“<code>feh -R 1 &lt;name&gt;</code>” in the foreground; terminate with
+“<code>ctrl-C fg ctrl-C</code>”. <em>Switching between</em>
+<strong>Mirror</strong> <em>and</em> <strong>Audio</strong> <em>modes
+during an active connection is possible: in</em> <strong>Mirror</strong>
+<em>mode, stop mirroring (or close the mirror window) and start an</em>
+<strong>Audio</strong> <em>mode connection, switch back by initiating
+a</em> <strong>Mirror</strong> <em>mode connection; cover-art display
+stops/restarts as you leave/re-enter</em> <strong>Audio</strong>
+<em>mode.</em></p>
 <ul>
-<li><strong>Note that Apple DRM (as found in Apple TV app content on the
-client) cannot be decrypted by UxPlay, and (unlike a true AppleTV), the
-UxPlay server does not allow the Apple client to run a http connection
-on the server that directly streams content from the internet to the
-server, instead of streaming it to the client, and then re-streaming to
-the server.</strong></li>
+<li><strong>Note that Apple video-DRM (as found in AppleTV.app content
+on the client) cannot be decrypted by UxPlay, and (unlike a true
+AppleTV), the UxPlay server does not allow the Apple client to run a
+http connection on the server that directly streams content from the
+internet to the server, instead of streaming it to the client, and then
+re-streaming to the server. Unlike AppleTV.app, DRM-free apps like
+youtube.app can be viewed and listened to in Mirror mode, but using the
+youtube.app icon for AirPlay video will only send ALAC sound without the
+accompanying video.</strong></li>
 </ul>
 <h3
 id="possibility-for-using-hardware-accelerated-h264-video-decoding-if-available.">Possibility
@@ -203,7 +220,7 @@ earlier</strong>.</li>
 <li><code>make</code></li>
 <li><code>sudo make install</code> (you can afterwards uninstall with
 <code>sudo make uninstall</code> in the same directory in which this was
-run)</li>
+run).</li>
 <li>Install GStreamer plugins that you need:
 <code>sudo apt-get install gstreamer1.0-&lt;plugin&gt;</code>; values of
 <code>&lt;plugin&gt;</code> needed are: “<strong>plugins-base</strong>”,
@@ -242,11 +259,13 @@ prevents UxPlay from receiving client connection requests unless some
 network ports are opened. See <a
 href="#troubleshooting">Troubleshooting</a> below for help with this or
 other problems.</p>
-<p>One common problem involves GStreamer attempting to use
+<p><strong>One common problem involves GStreamer attempting to use
 incorrectly-configured or absent accelerated hardware h264 video
 decoding (e.g., VAAPI). Try “<code>uxplay -avdec</code>” to force
 software video decoding; if this works you can then try to fix
-accelerated hardware video decoding if you need it. See <a
+accelerated hardware video decoding if you need it, or just uninstall
+the GStreamer VAAPI plugin. If your system uses the Wayland compositor
+for graphics, use “<code>uxplay -vs waylandsink</code>”.</strong> See <a
 href="#usage">Usage</a> for more run-time options.</p>
 <p><strong>Raspberry Pi</strong>: GStreamer-1.18.4 or later required for
 hardware video decoding; for 1.20 or earlier, also see <a
@@ -288,9 +307,8 @@ graphics).</p></li>
 libplist-devel avahi-compat-mDNSResponder-devel (+ libX11-devel for
 ZOOMFIX). The required GStreamer packages are: gstreamer-devel
 gstreamer-plugins-base-devel gstreamer-plugins-libav
-gstreamer-plugins-bad (+ gstreamer-plugins-vaapi for Intel graphics);
-you may need to use the version of gstreamer-plugins-libav for OpenSUSE
-from <a
+gstreamer-plugins-bad (+ gstreamer-plugins-vaapi for Intel graphics); in
+some cases, you may need to use gstreamer packages for OpenSUSE from <a
 href="https://ftp.gwdg.de/pub/linux/misc/packman/suse/">Packman</a>
 “Essentials”.</p></li>
 <li><p><strong>Arch Linux</strong> (sudo pacman -Syu) openssl libplist
@@ -393,15 +411,6 @@ locks the screen orientation against switching between portrait and
 landscape mode as the device is rotated).</p>
 <h1 id="usage">Usage</h1>
 <p>Options:</p>
-<p><strong>-p</strong> allows you to select the network ports used by
-UxPlay (these need to be opened if the server is behind a firewall). By
-itself, -p sets “legacy” ports TCP 7100, 7000, 7001, UDP 6000, 6001,
-7011. -p n (e.g. -p 35000) sets TCP and UDP ports n, n+1, n+2. -p
-n1,n2,n3 (comma-separated values) sets each port separately; -p n1,n2
-sets ports n1,n2,n2+1. -p tcp n or -p udp n sets just the TCP or UDP
-ports. Ports must be in the range [1024-65535].</p>
-<p>If the -p option is not used, the ports are chosen dynamically
-(randomly), which will not work if a firewall is running.</p>
 <p><strong>-n server_name</strong> (Default: UxPlay);
 server_name@_hostname_ will be the name that appears offering AirPlay
 services to your iPad, iPhone etc, where <em>hostname</em> is the name
@@ -430,39 +439,19 @@ Recommendation: <strong>don’t use this option</strong> unless there is
 some special reason to use it.</p>
 <p><strong>-fs</strong> uses fullscreen mode, but only works with
 Wayland or VAAPI plugins.</p>
-<p><strong>-fps n</strong> sets a maximum frame rate (in frames per
-second) for the AirPlay client to stream video; n must be a whole number
-less than 256. (The client may choose to serve video at any frame rate
-lower than this; default is 30 fps.) A setting below 30 fps might be
-useful to reduce latency if you are running more than one instance of
-uxplay at the same time. <em>This setting is only an advisory to the
-client device, so setting a high value will not force a high
-framerate.</em> (You can test using “-vs fpsdisplaysink” to see what
-framerate is being received, or use the option -FPSdata which displays
-video-stream performance data continuously sent by the client during
-video-streaming.)</p>
-<p><strong>-FPSdata</strong> Turns on monitoring of regular reports
-about video streaming performance that are sent by the client. These
-will be displayed in the terminal window if this option is used. The
-data is updated by the client at 1 second intervals.</p>
-<p><strong>-m</strong> generates a random MAC address to use instead of
-the true hardware MAC number of the computer’s network card. (Different
-server_name, MAC addresses, and network ports are needed for each
-running uxplay if you attempt to run two instances of uxplay on the same
-computer.) If UxPlay fails to find the true MAC address of a network
-card, (more specifically, the MAC address used by the first active
-network interface detected) a random MAC address will be used even if
-option <strong>-m</strong> was not specifed. (Note that a random MAC
-address will be different each time UxPlay is started).</p>
-<p>Also: image transforms that had been added to RPiPlay have been
-ported to UxPlay:</p>
-<p><strong>-f {H|V|I}</strong> implements “videoflip” image transforms:
-H = horizontal flip (right-left flip, or mirror image); V = vertical
-flip ; I = 180 degree rotation or inversion (which is the combination of
-H with V).</p>
-<p><strong>-r {R|L}</strong> 90 degree Right (clockwise) or Left
-(counter-clockwise) rotations; these are carried out after any
-<strong>-f</strong> transforms.</p>
+<p><strong>-p</strong> allows you to select the network ports used by
+UxPlay (these need to be opened if the server is behind a firewall). By
+itself, -p sets “legacy” ports TCP 7100, 7000, 7001, UDP 6000, 6001,
+7011. -p n (e.g. -p 35000) sets TCP and UDP ports n, n+1, n+2. -p
+n1,n2,n3 (comma-separated values) sets each port separately; -p n1,n2
+sets ports n1,n2,n2+1. -p tcp n or -p udp n sets just the TCP or UDP
+ports. Ports must be in the range [1024-65535].</p>
+<p>If the -p option is not used, the ports are chosen dynamically
+(randomly), which will not work if a firewall is running.</p>
+<p><strong>-avdec</strong> forces use of software h264 decoding using
+Gstreamer element avdec_h264 (libav h264 decoder). This option should
+prevent autovideosink choosing a hardware-accelerated videosink plugin
+such as vaapisink.</p>
 <p><strong>-vp <em>parser</em></strong> choses the GStreamer pipeline’s
 h264 parser element, default is h264parse. Using quotes “…” allows
 options to be added.</p>
@@ -507,10 +496,6 @@ Lite).</p>
 <p><strong>-rpiwl</strong> Equivalent to “-v4l2 -vs waylandsink”, for
 Raspberry Pi “Desktop” systems using the Wayland video compositor (use
 for Ubuntu 21.10 for Raspberry Pi 4B).</p>
-<p><strong>-avdec</strong> forces use of software h264 decoding using
-Gstreamer element avdec_h264 (libav h264 decoder). This option should
-prevent autovideosink choosing a hardware-accelerated videosink plugin
-such as vaapisink.</p>
 <p><strong>-as <em>audiosink</em></strong> chooses the GStreamer
 audiosink, instead of letting autoaudiosink pick it for you. Some
 audiosink choices are: pulsesink, alsasink, osssink, oss4sink, and
@@ -519,7 +504,21 @@ to be included with the audiosink name. (Some choices of audiosink might
 not work on your system.)</p>
 <p><strong>-as 0</strong> (or just <strong>-a</strong>) suppresses
 playing of streamed audio, but displays streamed video.</p>
-<p><strong>-reset n</strong> sets a limit of n consective timeout
+<p><strong>-ca <em>filename</em></strong> provides a file (where
+<em>filename</em> can include a full path) used for output of “cover
+art” (from Apple Music, <em>etc.</em>,) in audio-only ALAC mode. This
+file is overwritten with the latest cover art as it arrives. Cover art
+(jpeg format) is discarded if this option is not used. Use with a image
+viewer that reloads the image if it changes, or regularly (<em>e.g.</em>
+once per second.). To achieve this, run
+“<code>uxplay -ca [path/to/]filename &amp;</code>” in the background,
+then run the the image viewer in the foreground. Example, using
+<code>feh</code> as the viewer: run
+“<code>feh -R 1 [path/to/]filename</code>” (in the same terminal window
+in which uxplay was put into the background). To quit, use
+<code>ctrl-C fg ctrl-C</code> to terminate the image viewer, bring
+<code>uxplay</code> into the foreground, and terminate it too.</p>
+<p><strong>-reset n</strong> sets a limit of n consecutive timeout
 failures of the client to respond to ntp requests from the server (these
 are sent every 3 seconds to check if the client is still present). After
 n failures, the client will be presumed to be offline, and the
@@ -531,6 +530,37 @@ client sends the “Stop Mirroring” signal. <em>This option is currently
 used by default in macOS, as the window created in macOS by GStreamer
 does not terminate correctly (it causes a segfault) if it is still open
 when the GStreamer pipeline is closed.</em></p>
+<p><strong>-FPSdata</strong> Turns on monitoring of regular reports
+about video streaming performance that are sent by the client. These
+will be displayed in the terminal window if this option is used. The
+data is updated by the client at 1 second intervals.</p>
+<p><strong>-fps n</strong> sets a maximum frame rate (in frames per
+second) for the AirPlay client to stream video; n must be a whole number
+less than 256. (The client may choose to serve video at any frame rate
+lower than this; default is 30 fps.) A setting below 30 fps might be
+useful to reduce latency if you are running more than one instance of
+uxplay at the same time. <em>This setting is only an advisory to the
+client device, so setting a high value will not force a high
+framerate.</em> (You can test using “-vs fpsdisplaysink” to see what
+framerate is being received, or use the option -FPSdata which displays
+video-stream performance data continuously sent by the client during
+video-streaming.)</p>
+<p><strong>-f {H|V|I}</strong> implements “videoflip” image transforms:
+H = horizontal flip (right-left flip, or mirror image); V = vertical
+flip ; I = 180 degree rotation or inversion (which is the combination of
+H with V).</p>
+<p><strong>-r {R|L}</strong> 90 degree Right (clockwise) or Left
+(counter-clockwise) rotations; these image transforms are carried out
+after any <strong>-f</strong> transforms.</p>
+<p><strong>-m</strong> generates a random MAC address to use instead of
+the true hardware MAC number of the computer’s network card. (Different
+server_name, MAC addresses, and network ports are needed for each
+running uxplay if you attempt to run two instances of uxplay on the same
+computer.) If UxPlay fails to find the true MAC address of a network
+card, (more specifically, the MAC address used by the first active
+network interface detected) a random MAC address will be used even if
+option <strong>-m</strong> was not specifed. (Note that a random MAC
+address will be different each time UxPlay is started).</p>
 <p><strong>-t <em>timeout</em></strong> will cause the server to
 relaunch (without stopping uxplay) if no connections have been present
 during the previous <em>timeout</em> seconds. You may wish to use this
@@ -723,20 +753,22 @@ connection is reset, the “frozen” mirror screen of the previous
 connection is left in place, and will be taken over by a new client
 connection when it is made.</p>
 <h3
-id="failure-to-decrypt-all-video-and-audio-streams-from-old-or-non-apple-clients">6.
-Failure to decrypt ALL video and audio streams from old or non-Apple
-clients:</h3>
-<p>This triggers an unending stream of error messages, and means that
-the audio decryption key (also used in video decryption) was not
-correctly extracted from data sent by the client. This should not happen
-for iOS 9.3 or later clients. However, if a client uses the same older
-version of the protocol that is used by the Windows-based AirPlay client
-emulator <em>AirMyPC</em>, the protocol can be switched to the older
-version by the setting <code>OLD_PROTOCOL_CLIENT_USER_AGENT_LIST</code>
-in lib/global.h. UxPlay reports the client’s “User Agent” string when it
-connects. If some other client also fails to decrypt all audio and
-video, try adding its “User Agent” string in place of “xxx” in the entry
-“AirMyPC/2.0;xxx” in global.h and rebuild uxplay.</p>
+id="protocol-issues-such-as-failure-to-decrypt-all-video-and-audio-streams-from-old-or-non-apple-clients">6.
+Protocol issues, such as failure to decrypt ALL video and audio streams
+from old or non-Apple clients:</h3>
+<p>A protocol failure may trigger an unending stream of error messages,
+and means that the audio decryption key (also used in video decryption)
+was not correctly extracted from data sent by the client. This should
+not happen for iOS 9.3 or later clients. However, if a client uses the
+same older version of the protocol that is used by the Windows-based
+AirPlay client emulator <em>AirMyPC</em>, the protocol can be switched
+to the older version by the setting
+<code>OLD_PROTOCOL_CLIENT_USER_AGENT_LIST</code> in
+<code>UxPlay/lib/global.h</code>. UxPlay reports the client’s “User
+Agent” string when it connects. If some other client also fails to
+decrypt all audio and video, try adding its “User Agent” string in place
+of “xxx” in the entry “AirMyPC/2.0;xxx” in global.h and rebuild
+uxplay.</p>
 <p>Note that Uxplay declares itself to be an AppleTV3,2 with a
 sourceVersion 220.68; this can also be changed in global.h. It had been
 thought that it was necessary for UxPlay to claim to be an older 32 bit
@@ -748,10 +780,15 @@ AppleTV6,2 with sourceVersion 380.20.1 (an AppleTV 4K 1st gen,
 introduced 2017, running tvOS 12.2.1); it seems that the use of “legacy”
 protocol just requires bit 27 (listed as “SupportsLegacyPairing”) of the
 “features” plist code (reported to the client by the AirPlay server) to
-be set.</p>
+be set. The “features” code and other settings are set in
+<code>UxPlay/lib/dnssdint.h</code>.</p>
 <h1 id="changelog">ChangeLog</h1>
+<p>1.54 2022-06-25 Add support for “Cover Art” display in Audio-only
+(ALAC) mode. Reverted a change that caused VAAPI to crash with AMD
+POLARIS graphics cards. Minor internal changes to plist code and uxplay
+option parsing.</p>
 <p>1.53 2022-06-13 Internal changes to audio sync code, revised
-documentation, minor bugfix (fix assertion crash when resent audio
+documentation, Minor bugfix (fix assertion crash when resent audio
 packets are empty).</p>
 <p>1.52 2022-05-05 Cleaned up initial audio sync code, and reformatted
 streaming debug output (readable aligned timestamps with decimal points

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# UxPlay 1.53:  AirPlay/AirPlay-Mirror server for Linux, macOS, and Unix.
+# UxPlay 1.54:  AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix.
 
 ### Now developed at the GitHub site [https://github.com/FDH2/UxPlay](https://github.com/FDH2/UxPlay) (where all user issues should be posted).
 
@@ -6,9 +6,9 @@
 Highlights:
 
    * GPLv3, open source.
-   * Support for both AirPlay Mirror and AirPlay Audio-only (Apple Lossless
-     ALAC) streaming protocols 
-     from current iOS/iPadOS 15.5 clients.
+   * Originally supported only AirPlay Mirror protocol, now has added support
+     for AirPlay Audio-only (Apple Lossless ALAC) streaming 
+     from current iOS/iPadOS 15.5 clients.  **There is no support for Airplay2 video-streaming protocol, and none is planned.**
    * macOS computers (2011 or later, both Intel and "Apple Silicon" M1
      systems) can act either as AirPlay clients, or
      as the server running UxPlay. Using AirPlay, UxPlay can
@@ -21,8 +21,8 @@ Highlights:
      "audiosinks", and a fully-user-configurable video streaming pipeline).
    * Support for server behind a firewall.
    * **New**: Support for Raspberry Pi, with hardware video acceleration using
-     Video4Linux2 (which supports both 32- and 64-bit systems, unlike deprecated
-     OpenMAX (omx), which it replaces). (For GStreamer < 1.22,
+     Video4Linux2 (vl42), which supports both 32- and 64-bit systems, unlike deprecated
+     OpenMAX (omx), which is being dropped by RPi distributions in favor of v4l2. (For GStreamer < 1.22,
      a [patch](https://github.com/FDH2/UxPlay/wiki/Gstreamer-Video4Linux2-plugin-patches)
      to the GStreamer Video4Linux2 plugin, available in the
      [UxPlay Wiki](https://github.com/FDH2/UxPlay/wiki), is required, unless
@@ -33,7 +33,7 @@ Highlights:
 This project is a GPLv3 open source unix AirPlay2 Mirror server for Linux, macOS, and \*BSD.
 It was initially developed by
 [antimof](http://github.com/antimof/Uxplay) using code 
-from [RPiPlay](https://github.com/FD-/RPiPlay), which in turn derives from
+from OpenMAX-based [RPiPlay](https://github.com/FD-/RPiPlay), which in turn derives from
 [AirplayServer](https://github.com/KqsMea8/AirplayServer),
 [shairplay](https://github.com/juhovh/shairplay), and [playfair](https://github.com/EstebanKubata/playfair).
 (The antimof site is no longer involved in
@@ -49,9 +49,10 @@ Its main use is to act like an AppleTV for screen-mirroring (with audio) of iOS/
 (iPhones, iPads, MacBooks) in a window
 on the server display (with the possibility of
 sharing that window on screen-sharing applications such as Zoom)
-on a host running Linux, macOS, or other unix.  UxPlay supports Apple's AirPlay 2
+on a host running Linux, macOS, or other unix.  UxPlay supports Apple's AirPlay2
 protocol using "Legacy Pairing", but some features are missing.
 (Details of what is publically known about Apple's AirPlay 2 protocol can be found
+[here](https://openairplay.github.io/airplay-spec/),
 [here](https://github.com/SteeBono/airplayreceiver/wiki/AirPlay2-Protocol) and
 [here](https://emanuelecozzi.net/docs/airplay2)).
 
@@ -64,21 +65,29 @@ through the avahi-daemon service, and is included in  most Linux distributions (
 service can also be provided by macOS, iOS or Windows servers).
 
 Connections to the UxPlay server by
-iOS/MacOS  clients can be initiated both in AirPlay Mirror mode (which streams
+iOS/MacOS  clients can be initiated both in **AirPlay Mirror** mode (which streams
 lossily-compressed AAC audio while mirroring the client screen,
-or in the alternative AirPlay Audio mode which streams
-Apple Lossless (ALAC) audio without screen mirroring (the accompanying cover art in
-this mode is not displayed, but metadata is displayed in the terminal).
-_Switching between these two modes during an active  connection is
-possible: in Mirror mode, close the mirror window and start an Audio mode connection,
-switch back by initiating a Mirror mode connection._
+or in the alternative **AirPlay Audio** mode which streams
+Apple Lossless (ALAC) audio without screen mirroring. In **Audio** mode,
+metadata is displayed in the uxplay terminal;
+if UxPlay option ``-ca <name>`` is used,
+the accompanying cover art is also output 
+to a periodically-updated file `<name>`, and can be viewed with
+a (reloading) graphics viewer of your choice such as `feh`:
+run "`uxplay -ca <name> &`" in the background, then run "``feh -R 1 <name>``"
+in the foreground; terminate with "`ctrl-C fg ctrl-C`".
+_Switching between_ **Mirror** _and_ **Audio** _modes  during an active  connection is
+possible: in_ **Mirror** _mode, stop mirroring (or close the mirror window) and start an_ **Audio** _mode connection,
+switch back by initiating a_ **Mirror** _mode connection; cover-art display stops/restarts as you leave/re-enter_ **Audio** _mode._
 
-* **Note that Apple DRM
-(as found in Apple TV app content on the client) cannot be decrypted by UxPlay,
+* **Note that Apple video-DRM
+(as found in AppleTV.app content on the client) cannot be decrypted by UxPlay,
 and (unlike a true AppleTV), the UxPlay server does not allow the Apple
 client to run a http connection on the server that directly streams
 content from the internet to the server, instead of 
-streaming it to the client, and then re-streaming to the server.**
+streaming it to the client, and then re-streaming to the server. Unlike AppleTV.app,  DRM-free apps like youtube.app
+can be viewed  and listened to in Mirror mode, but using the youtube.app icon for AirPlay video will only send
+ALAC sound  without the accompanying  video.**
 
 ### Possibility for using hardware-accelerated h264 video-decoding, if available.
 
@@ -186,20 +195,19 @@ for a distribution, use the cmake option `-DNO_MARCH_NATIVE=ON`.
    such as Zoom, see [ZOOMFIX compile-time option](#zoomfix-compile-time-option) below).
    **ZOOMFIX  is only needed for GStreamer-1.18.x or earlier**.
 5. `make`
-6. `sudo make install`    (you can afterwards uninstall
-    with `sudo make uninstall` in the same directory in which this was run)
-7.  Install GStreamer plugins that you
-    need: `sudo apt-get install gstreamer1.0-<plugin>`; values of
-    `<plugin>` needed are: "**plugins-base**", "**libav**" (for sound),
-    "**plugins-good**" (for v4l2 hardware h264 decoding)
-    and  "**plugins-bad**" (for h264 decoding).   Also needed may
-    be "**gl**" for OpenGL support (which may be useful, and should
-    be used with h264 decoding by the NVIDIA GPU), and "**x**" for
-    X11 support, although these may  already be installed; "**vaapi**"
-    is needed for hardware-accelerated h264 video decoding by Intel
-    or AMD  graphics (but not for use with NVIDIA using proprietary drivers).
-    Also install "**tools**" to get the utility gst-inspect-1.0 for
-    examining the GStreamer installation.
+6. `sudo make install` (you can afterwards uninstall with ``sudo make uninstall``
+   in the same directory in which this was run).
+7. Install GStreamer plugins that you need: `sudo apt-get install gstreamer1.0-<plugin>`;
+   values of `<plugin>` needed are: "**plugins-base**", "**libav**" (for sound),
+   "**plugins-good**" (for v4l2 hardware h264 decoding)
+   and  "**plugins-bad**" (for h264 decoding).   Also needed may
+   be "**gl**" for OpenGL support (which may be useful, and should
+   be used with h264 decoding by the NVIDIA GPU), and "**x**" for
+   X11 support, although these may  already be installed; "**vaapi**"
+   is needed for hardware-accelerated h264 video decoding by Intel
+   or AMD  graphics (but not for use with NVIDIA using proprietary drivers).
+   Also install "**tools**" to get the utility gst-inspect-1.0 for
+   examining the GStreamer installation.
 
 _If you intend to modify the code, use a separate "build" directory:
 replace_  "`cmake  [ ] .`" _by_  "``mkdir build ; cd build ; cmake [ ] ..``"; _you can then clean
@@ -224,11 +232,12 @@ UxPlay from receiving client connection requests unless some network ports
 are opened. See [Troubleshooting](#troubleshooting) below for
 help with this or other problems.
 
-One common problem involves GStreamer
+**One common problem involves GStreamer
 attempting to use incorrectly-configured or absent accelerated hardware h264
 video decoding (e.g., VAAPI).
 Try "`uxplay -avdec`" to force software video decoding; if this works you can
-then try to fix accelerated hardware video decoding if you need it.
+then try to fix accelerated hardware video decoding if you need it, or just uninstall the GStreamer VAAPI plugin. If
+your system uses the Wayland compositor for graphics, use "`uxplay -vs waylandsink`".**
 See [Usage](#usage) for more run-time options.
 
 **Raspberry Pi**: GStreamer-1.18.4 or later required for hardware video decoding; for 1.20 or earlier, also see
@@ -262,8 +271,8 @@ gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-libav gstreamer1-plugi
  * **OpenSUSE:**
 (sudo zypper install) libopenssl-devel libplist-devel
 avahi-compat-mDNSResponder-devel (+ libX11-devel for ZOOMFIX).  The required
-GStreamer packages are: gstreamer-devel gstreamer-plugins-base-devel gstreamer-plugins-libav gstreamer-plugins-bad (+ gstreamer-plugins-vaapi for Intel graphics);
-you may need to use the version of gstreamer-plugins-libav for OpenSUSE from [Packman](https://ftp.gwdg.de/pub/linux/misc/packman/suse/) "Essentials".
+GStreamer packages are: gstreamer-devel gstreamer-plugins-base-devel gstreamer-plugins-libav gstreamer-plugins-bad (+ gstreamer-plugins-vaapi for Intel graphics); in some cases, 
+you may need to use gstreamer packages for OpenSUSE from [Packman](https://ftp.gwdg.de/pub/linux/misc/packman/suse/) "Essentials".
 
 
 * **Arch Linux**
@@ -350,23 +359,11 @@ as the device is rotated).
 
 Options:
 
-**-p**  allows you to select the network ports used by UxPlay (these need
-   to be opened if the server is behind a firewall).   By itself, -p sets
-   "legacy" ports TCP 7100, 7000, 7001, UDP 6000, 6001, 7011.   -p n (e.g. -p
-   35000)  sets TCP and UDP ports n, n+1, n+2.  -p n1,n2,n3 (comma-separated
-   values) sets each port separately; -p n1,n2 sets ports n1,n2,n2+1.  -p tcp n
-   or -p udp n sets just the TCP or UDP ports.  Ports must be in the range
-   [1024-65535].
-
-If the -p option is not used, the ports are chosen dynamically (randomly),
-which will not work if a firewall is running.
-
 **-n server_name** (Default: UxPlay);  server_name@_hostname_ will be the name that appears offering
    AirPlay services to your iPad, iPhone etc, where _hostname_ is the name of the server running uxplay. 
    This will also now be the name shown above the mirror display (X11)  window.
 
 **-nh** Do not append "@_hostname_" at the end of the AirPlay server name.
-
 
 **-s wxh** (e.g. -s 1920x1080 , which is the default ) sets the display resolution (width and height,
    in pixels).   (This may be a
@@ -391,40 +388,20 @@ which will not work if a firewall is running.
 
 **-fs** uses fullscreen mode, but only works with Wayland or VAAPI plugins.
 
-**-fps n** sets a maximum frame rate (in frames per second) for the AirPlay
-   client to stream video; n must be a whole number less than 256.
-   (The client may choose to serve video at any frame rate lower
-   than this;  default is 30 fps.)  A setting below 30 fps might be useful to
-   reduce latency if you are running more than one instance of uxplay at the same time.
-   _This setting is only an advisory to
-   the client device, so setting a high value will not force a high framerate._
-   (You can test using "-vs fpsdisplaysink" to see what framerate is being
-   received, or use the option -FPSdata which displays video-stream performance data
-   continuously sent by the client during video-streaming.)
+**-p**  allows you to select the network ports used by UxPlay (these need
+   to be opened if the server is behind a firewall).   By itself, -p sets
+   "legacy" ports TCP 7100, 7000, 7001, UDP 6000, 6001, 7011.   -p n (e.g. -p
+   35000)  sets TCP and UDP ports n, n+1, n+2.  -p n1,n2,n3 (comma-separated
+   values) sets each port separately; -p n1,n2 sets ports n1,n2,n2+1.  -p tcp n
+   or -p udp n sets just the TCP or UDP ports.  Ports must be in the range
+   [1024-65535].
 
-**-FPSdata** Turns on monitoring of regular reports about video streaming performance
-   that are sent by the client.  These will be displayed in the terminal window if this
-   option is used.   The data is updated by the client at 1 second intervals.
+If the -p option is not used, the ports are chosen dynamically (randomly),
+which will not work if a firewall is running.
 
-**-m**  generates a random MAC address to use instead of the true hardware MAC
-   number of the computer's network card.   (Different server_name,  MAC
-   addresses,  and network ports are needed for each running uxplay  if you
-   attempt to  run two instances of uxplay on the same computer.)
-   If UxPlay fails to find the true MAC address of a  network card, (more
-   specifically, the MAC address used by the first active network interface detected)
-   a random MAC address will be used even if option **-m** was not specifed.
-   (Note that a random MAC address will be different each time UxPlay is started).
-
-
-Also: image transforms that had been added to RPiPlay have been ported to UxPlay:
-
-**-f {H|V|I}**  implements "videoflip" image transforms: H = horizontal flip
-(right-left flip, or mirror image); V = vertical flip ;  I =
-180 degree rotation or inversion (which is the combination of H with V).
-
-**-r {R|L}**  90 degree Right (clockwise) or Left (counter-clockwise)
-   rotations; these are carried out after any **-f** transforms.
-
+**-avdec** forces use of software h264 decoding using Gstreamer element avdec_h264 (libav h264 decoder). This
+   option should prevent autovideosink choosing a hardware-accelerated videosink plugin such as vaapisink.
+   
 **-vp _parser_** choses the GStreamer pipeline's h264 parser element, default is h264parse. Using
    quotes "..." allows options to be added.
    
@@ -463,9 +440,6 @@ Also: image transforms that had been added to RPiPlay have been ported to UxPlay
    Pi "Desktop" systems using the Wayland video compositor (use for
    Ubuntu 21.10 for Raspberry Pi 4B).
 
-**-avdec** forces use of software h264 decoding using Gstreamer element avdec_h264 (libav h264 decoder). This
-   option should prevent autovideosink choosing a hardware-accelerated videosink plugin such as vaapisink.
-   
 **-as _audiosink_** chooses the GStreamer audiosink, instead of letting
    autoaudiosink pick it for you.  Some audiosink choices are:  pulsesink, alsasink, 
    osssink, oss4sink, and osxaudiosink (for macOS).  Using quotes
@@ -474,7 +448,15 @@ Also: image transforms that had been added to RPiPlay have been ported to UxPlay
 
 **-as 0**  (or just **-a**) suppresses playing of streamed audio, but displays streamed video.
 
-**-reset n** sets a limit of n consective timeout failures of the client to respond to ntp requests
+**-ca _filename_** provides a file (where _filename_ can include a full path) used for output of "cover art"
+   (from Apple Music, _etc._,) in audio-only ALAC mode.   This file is overwritten with the latest cover art as
+   it arrives.   Cover art (jpeg format) is discarded if this option is not used.    Use with a image viewer that reloads the image
+   if it changes, or regularly (_e.g._ once per second.).    To achieve this,  run "`uxplay -ca [path/to/]filename &`" in the background,
+   then run the the image viewer in the foreground.   Example, using `feh` as the viewer: run "``feh -R 1 [path/to/]filename``" (in
+   the same terminal window in which uxplay was put into the background).   To quit, use ```ctrl-C fg ctrl-C``` to terminate
+   the image viewer, bring ``uxplay`` into the foreground, and terminate it too.
+
+**-reset n** sets a limit of n consecutive timeout failures of the client to respond to ntp requests
    from the server (these are sent every 3 seconds to check if the client is still present).   After
    n failures, the client will be presumed to be offline, and the connection will be reset to allow a new
    connection.   The default value of n is 5; the value n = 0 means "no limit" on timeouts.
@@ -483,6 +465,37 @@ Also: image transforms that had been added to RPiPlay have been ported to UxPlay
    sends the "Stop Mirroring" signal. _This option is currently used by default in macOS,
    as the  window created in macOS by GStreamer does not terminate correctly (it causes a segfault)
    if it is still open when the GStreamer pipeline is closed._
+
+**-FPSdata** Turns on monitoring of regular reports about video streaming performance
+   that are sent by the client.  These will be displayed in the terminal window if this
+   option is used.   The data is updated by the client at 1 second intervals.
+
+**-fps n** sets a maximum frame rate (in frames per second) for the AirPlay
+   client to stream video; n must be a whole number less than 256.
+   (The client may choose to serve video at any frame rate lower
+   than this;  default is 30 fps.)  A setting below 30 fps might be useful to
+   reduce latency if you are running more than one instance of uxplay at the same time.
+   _This setting is only an advisory to
+   the client device, so setting a high value will not force a high framerate._
+   (You can test using "-vs fpsdisplaysink" to see what framerate is being
+   received, or use the option -FPSdata which displays video-stream performance data
+   continuously sent by the client during video-streaming.)
+
+**-f {H|V|I}**  implements "videoflip" image transforms: H = horizontal flip
+   (right-left flip, or mirror image); V = vertical flip ;  I =
+   180 degree rotation or inversion (which is the combination of H with V).
+
+**-r {R|L}**  90 degree Right (clockwise) or Left (counter-clockwise)
+   rotations; these image transforms are carried out after any **-f** transforms.
+
+**-m**  generates a random MAC address to use instead of the true hardware MAC
+   number of the computer's network card.   (Different server_name,  MAC
+   addresses,  and network ports are needed for each running uxplay  if you
+   attempt to  run two instances of uxplay on the same computer.)
+   If UxPlay fails to find the true MAC address of a  network card, (more
+   specifically, the MAC address used by the first active network interface detected)
+   a random MAC address will be used even if option **-m** was not specifed.
+   (Note that a random MAC address will be different each time UxPlay is started).
 
 **-t _timeout_**  will cause the server to relaunch (without stopping uxplay) if no connections
    have been present during the previous _timeout_ seconds.  You may wish to use this if the Server
@@ -631,15 +644,16 @@ default limit is not right  for your network,  it can be modified using the opti
 starts to recover after ntp timeouts, a corrupt video packet from before the timeout may trigger a "connection reset by peer"  error, which also causes UxPlay to reset the
 connection. When the connection is reset, the "frozen" mirror screen of the previous connection is left in place, and will be taken over by a new client connection when it is made.
 
-### 6.  Failure to decrypt ALL video and audio streams from old or non-Apple clients:
+### 6. Protocol issues, such as failure to decrypt ALL video and audio streams from old or non-Apple clients:
 
-This triggers an unending stream of error messages, and means that the
+A protocol failure may trigger an unending stream of error messages, and means that the
 audio decryption key (also used in video decryption) 
 was not correctly extracted from data sent by the  client.
 This should not happen for iOS 9.3 or later clients.  However, if a client 
 uses the same  older version of the protocol that is used by the Windows-based
 AirPlay client emulator _AirMyPC_, the protocol can be switched to the older version
-by the setting ```OLD_PROTOCOL_CLIENT_USER_AGENT_LIST``` in lib/global.h.
+by the setting ```OLD_PROTOCOL_CLIENT_USER_AGENT_LIST``` 
+in `UxPlay/lib/global.h`.
 UxPlay reports the  client's "User Agent" string when it connects. If 
 some other client also fails to decrypt all audio and video, try adding 
 its "User Agent" string in place of "xxx" in the  entry "AirMyPC/2.0;xxx" 
@@ -656,10 +670,15 @@ sourceVersion 380.20.1 (an AppleTV 4K 1st gen, introduced 2017, running
 tvOS 12.2.1); it seems that the use of "legacy" protocol just requires bit 27 (listed as
 "SupportsLegacyPairing") of the
 "features" plist code (reported to the client by the AirPlay server) to be set.
+The "features" code and other settings are set in `UxPlay/lib/dnssdint.h`.
 
 # ChangeLog
-1.53 2022-06-13   Internal changes to  audio sync code, revised documentation, 
-                  minor bugfix (fix assertion crash when resent audio packets are empty).
+1.54 2022-06-25   Add support for "Cover Art" display in Audio-only (ALAC) mode. Reverted a change 
+                  that caused  VAAPI to crash with AMD POLARIS graphics cards.   Minor internal changes to
+                  plist code and uxplay option parsing.
+
+1.53 2022-06-13   Internal changes to audio sync code, revised documentation, 
+                  Minor bugfix (fix assertion crash when resent audio packets are empty).
 
 1.52 2022-05-05   Cleaned up initial audio sync code, and reformatted
                   streaming debug output (readable aligned timestamps with

--- a/lib/dnssdint.h
+++ b/lib/dnssdint.h
@@ -20,7 +20,10 @@
 #define RAOP_VN "65537"
 #define RAOP_PK "b07727d6f6cd6e08b58ede525ec3cdeaa252ad9f683feb212ef8a205246554e7"
 
-#define AIRPLAY_FEATURES "0x5A7FFEE6"
+
+#define AIRPLAY_FEATURES_1 "0x5A7FFEE6"  /* first 32 bits of features */
+#define AIRPLAY_FEATURES_2 "0x0"         /* second 32 bits of features */
+#define AIRPLAY_FEATURES  AIRPLAY_FEATURES_1 "," AIRPLAY_FEATURES_2 
 #define AIRPLAY_SRCVERS GLOBAL_VERSION /*defined in global.h */
 #define AIRPLAY_FLAGS "0x4"
 #define AIRPLAY_VV "2"

--- a/lib/dnssdint.h
+++ b/lib/dnssdint.h
@@ -4,10 +4,12 @@
 #include "global.h"
 #define RAOP_TXTVERS "1"
 #define RAOP_CH "2"             /* Audio channels: 2 */
-#define RAOP_CN "0,1,2,3"           /* Audio codec: PCM, ALAC, AAC, AAC ELD */
-#define RAOP_ET "0,3,5"           /* Encryption type: None, FairPlay, FairPlay SAPv2.5 */
+#define RAOP_CN "0,1,2,3"       /* Audio codec: PCM, ALAC, AAC, AAC ELD */
+#define RAOP_ET "0,3,5"         /* Encryption type: None, FairPlay, FairPlay SAPv2.5 */
 #define RAOP_VV "2"
-#define RAOP_FT "0x5A7FFEE6"
+#define FEATURES_1 "0x5A7FFEE6" /* first 32 bits of features */
+#define FEATURES_2 "0x0"        /* second 32 bits of features */
+#define RAOP_FT FEATURES_1 "," FEATURES_2
 #define RAOP_RHD "5.6.0.0"
 #define RAOP_SF "0x4"
 #define RAOP_SV "false"
@@ -20,9 +22,9 @@
 #define RAOP_VN "65537"
 #define RAOP_PK "b07727d6f6cd6e08b58ede525ec3cdeaa252ad9f683feb212ef8a205246554e7"
 
-
-#define AIRPLAY_FEATURES_1 "0x5A7FFEE6"  /* first 32 bits of features */
-#define AIRPLAY_FEATURES_2 "0x0"         /* second 32 bits of features */
+/* use same features for RAOP and AIRPLAY: is this correct? */
+#define AIRPLAY_FEATURES_1 FEATURES_1
+#define AIRPLAY_FEATURES_2 FEATURES_2
 #define AIRPLAY_FEATURES  AIRPLAY_FEATURES_1 "," AIRPLAY_FEATURES_2 
 #define AIRPLAY_SRCVERS GLOBAL_VERSION /*defined in global.h */
 #define AIRPLAY_FLAGS "0x4"

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -47,12 +47,15 @@ raop_handler_info(raop_conn_t *conn,
     int pk_len = 0;
     char *pk = utils_parse_hex(AIRPLAY_PK, strlen(AIRPLAY_PK), &pk_len);
 
+    uint64_t features = ((uint64_t) strtoul(AIRPLAY_FEATURES_2, NULL, 16)) << 32;
+    features += (uint64_t) strtoul(AIRPLAY_FEATURES_1, NULL, 16);
+
     plist_t r_node = plist_new_dict();
 
     plist_t txt_airplay_node = plist_new_data(airplay_txt, airplay_txt_len);
     plist_dict_set_item(r_node, "txtAirPlay", txt_airplay_node);
 
-    plist_t features_node = plist_new_uint((uint64_t) 0x1E << 32 | 0x5A7FFFF7);
+    plist_t features_node = plist_new_uint(features);
     plist_dict_set_item(r_node, "features", features_node);
 
     plist_t name_node = plist_new_string(name);

--- a/renderers/video_renderer_gstreamer.c
+++ b/renderers/video_renderer_gstreamer.c
@@ -97,7 +97,7 @@ static logger_t *logger = NULL;
 static unsigned short width, height, width_source, height_source;  /* not currently used */
 static bool first_packet = false;
 
-/* apple uses colorimetry=1:3:5:1 (not recognized by gstreamer)  *
+/* apple uses colorimetry=1:3:5:1 (not recognized by gstreamer v4l2)  *
  * See .../gst-libs/gst/video/video-color.h in gst-plugins-base  *
  * range = 1   -> GST_VIDEO_COLOR_RANGE_0_255      ("full RGB")  * 
  * matrix = 3  -> GST_VIDEO_COLOR_MATRIX_BT709                   *
@@ -106,7 +106,7 @@ static bool first_packet = false;
  * closest is BT709, 2:3:5:1 with                                *
  * range = 2 -> GST_VIDEO_COLOR_RANGE_16_235 ("limited RGB")     */  
 
-static const char h264_caps[]="video/x-h264,colorimetry=bt709,stream-format=(string)byte-stream,alignment=(string)au";
+static const char h264_caps[]="video/x-h264,stream-format=(string)byte-stream,alignment=(string)au";
 
 void video_renderer_size(float *f_width_source, float *f_height_source, float *f_width, float *f_height) {
     width_source = (unsigned short) *f_width_source;

--- a/uxplay.1
+++ b/uxplay.1
@@ -30,11 +30,6 @@ UxPlay 1.53: An open\-source AirPlay mirroring server based on RPiPlay
 .PP
 .TP
 \fB\-avdec\fR    Force software h264 video decoding with libav decoder.
-
-
-
-
-
 .TP
 \fB\-vp\fI prs \fR  Choose GStreamer h264 parser; default "h264parse"
 .TP

--- a/uxplay.1
+++ b/uxplay.1
@@ -1,4 +1,4 @@
-.TH UXPLAY "1" "June 2022" "1.53" "User Commands"
+.TH UXPLAY "1" "June 2022" "1.54" "User Commands"
 .SH NAME
 uxplay \- start AirPlay server
 .SH SYNOPSIS
@@ -16,15 +16,9 @@ UxPlay 1.53: An open\-source AirPlay mirroring server based on RPiPlay
 .B
 \fB\-s\fR wxh[@r]Set display resolution [refresh_rate] default 1920x1080[@60]
 .TP
-\fB\-o\fR        Set mirror "overscanned" mode on (not usually needed)
+\fB\-o\fR        Set display "overscanned" mode on (not usually needed)
 .TP
 \fB-fs\fR       Full-screen (only with Wayland and VAAPI plugins)
-.TP
-\fB\-fps\fR n    Set maximum allowed streaming framerate, default 30
-.TP
-\fB\-f\fR {H|V|I}Horizontal|Vertical flip, or both=Inversion=rotate 180 deg
-.TP
-\fB\-r\fR {R|L}  Rotate 90 degrees Right (cw) or Left (ccw)
 .TP
 \fB\-p\fR        Use legacy ports UDP 6000:6001:7011 TCP 7000:7001:7100
 .TP
@@ -35,9 +29,12 @@ UxPlay 1.53: An open\-source AirPlay mirroring server based on RPiPlay
    "\-p tcp n" or "\-p udp n" sets TCP or UDP ports separately.
 .PP
 .TP
-\fB\-m\fR        Use random MAC address (use for concurrent UxPlay's)
-.TP
-\fB\-t\fR n      Relaunch server if no connection existed in last n seconds
+\fB\-avdec\fR    Force software h264 video decoding with libav decoder.
+
+
+
+
+
 .TP
 \fB\-vp\fI prs \fR  Choose GStreamer h264 parser; default "h264parse"
 .TP
@@ -68,8 +65,6 @@ UxPlay 1.53: An open\-source AirPlay mirroring server based on RPiPlay
 .TP
 \fB\-rpiwl\fR    Same as "-v4l2 -vs waylandsink" for RPi using Wayland.
 .TP
-\fB\-avdec\fR    Force software h264 video decoding with libav decoder.
-.TP
 \fB\-as\fI sink\fR  Choose the GStreamer audiosink; default "autoaudiosink"
 .IP
    choices:pulsesink,alsasink,osssink,oss4sink,osxaudiosink,..
@@ -77,11 +72,23 @@ UxPlay 1.53: An open\-source AirPlay mirroring server based on RPiPlay
 .TP
 \fB\-as\fR 0     (or \fB\-a\fR) Turn audio off, streamed video only.
 .TP
-\fB\-reset\fR n  Reset after 3n seconds client silence (default 10, 0=never).
+\fB\-ca\fI fn \fR   In Airplay Audio (ALAC) mode, write cover-art to file fn.
+.TP
+\fB\-reset\fR n  Reset after 3n seconds client silence (default 5, 0=never).
 .TP
 \fB\-nc\fR       Do not close video window when client stops mirroring
 .TP
 \fB\-FPSdata\fR  Show video-streaming performance reports sent by client.
+.TP
+\fB\-fps\fR n    Set maximum allowed streaming framerate, default 30
+.TP
+\fB\-f\fR {H|V|I}Horizontal|Vertical flip, or both=Inversion=rotate 180 deg
+.TP
+\fB\-r\fR {R|L}  Rotate 90 degrees Right (cw) or Left (ccw)
+.TP
+\fB\-m\fR        Use random MAC address (use for concurrent UxPlay's)
+.TP
+\fB\-t\fR n      Relaunch server if no connection existed in last n seconds
 .TP
 \fB\-vdmp\fR [n] Dump h264 video output to "fn.h264"; fn="videodump", change
 .IP

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -586,11 +586,15 @@ int main (int argc, char *argv[]) {
             video_converter.erase();
             video_converter = "videoconvert";
 	} else if (arg == "-v4l2" || arg == "-rpi") {
+            video_parser.erase();
+            video_parser = "h264parse ! capssetter caps=\"video/x-h264, colorimetry=bt709\"";
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();
             video_converter = "v4l2convert";
 	} else if (arg == "-rpifb") {
+            video_parser.erase();
+            video_parser = "h264parse ! capssetter caps=\"video/x-h264, colorimetry=bt709\"";
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();
@@ -598,6 +602,8 @@ int main (int argc, char *argv[]) {
             videosink.erase();
             videosink = "kmssink";
         } else if (arg == "-rpiwl" ) {
+            video_parser.erase();
+            video_parser = "h264parse ! capssetter caps=\"video/x-h264, colorimetry=bt709\"";
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();


### PR DESCRIPTION
includes a fix for a crash  of VAAPI with AMD Polaris graphics cards, due to a RPi-fix that should have only been applied to Video4Linux2 systems.    ALAC-mode cover-art support seems to be the end of the line for "easy"  enhancements to UxPlay, since there is no intention of supporting Airplay2 video streaming, which needs both a DMAP and a https server..   Reports of tests with iOS 16 beta suggests that LegacyPairing  and hence UxPlay will still be supported by  iOS 16.
