### PR TITLE
1.56  Minor update to RPi options: "bt709" color fix is merged to GStreamer; new patches available.

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,6 +1,6 @@
 <h1
-id="uxplay-1.55-airplay-mirror-and-airplay-audio-server-for-linux-macos-and-unix.">UxPlay
-1.55: AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and
+id="uxplay-1.56-airplay-mirror-and-airplay-audio-server-for-linux-macos-and-unix.">UxPlay
+1.56: AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and
 Unix.</h1>
 <h3
 id="now-developed-at-the-github-site-httpsgithub.comfdh2uxplay-where-all-user-issues-should-be-posted.">Now
@@ -289,29 +289,28 @@ improvements from GStreamer-1.22. Patches for GStreamer-1.18.4 and later
 are <a
 href="https://github.com/FDH2/UxPlay/wiki/Gstreamer-Video4Linux2-plugin-patches">available
 with instructions in the UxPlay Wiki</a>.</p></li>
-<li><p>Currently, a workaround implemented in UxPlay-1.55 as the new
-uxplay option <code>-bt709</code> is needed because Apple are using an
-uncommon “full-range color” variant of the “bt709” color standard used
-for digital TV broadcasting, which is currently not recognized by the
-Video4Linux2 plugin. It is planned to eventually add support for Apple’s
-variant “bt709” color to GStreamer; after this has been done, this
-option will no longer be needed (and updated patches for backports will
-be provided in the UxPlay Wiki).</p></li>
 </ul>
 <p>The basic uxplay options for R Pi are
-<code>uxplay -bt709 -v4l2 [-vs &lt;videosink&gt;]</code>. On a system
-without X11 (like R Pi OS Lite) with framebuffer video, use
-<code>&lt;videosink&gt;</code> = <code>kmssink</code>. With the Wayland
-video compositor (as in recent Ubuntu for R Pi) use
+<code>uxplay -v4l2 [-vs &lt;videosink&gt;]</code>. The choice
+<code>&lt;videosink&gt;</code> = <code>glimagesink</code> is sometimes
+useful. On a system without X11 (like R Pi OS Lite) with framebuffer
+video, use <code>&lt;videosink&gt;</code> = <code>kmssink</code>. With
+the Wayland video compositor (as in recent Ubuntu for R Pi) use
 <code>&lt;videosink&gt;</code> = <code>waylandsink</code>. For
 convenience, these options are also available combined in options
-<code>-rpi</code>,<code>-rpifb</code>, <code>-rpiwl</code>, respectively
-provided for X11, framebuffer, and Wayland systems. You may find the
-simple “uxplay -bt709”, (which lets GStreamer try to find the best video
-solution by itself) provides the best results.</p>
+<code>-rpi</code>, <code>-rpigl</code> <code>-rpifb</code>,
+<code>-rpiwl</code>, respectively provided for X11, X11 with OpenGL,
+framebuffer, and Wayland systems. You may find the simple “uxplay”,
+(which lets GStreamer try to find the best video solution by itself)
+provides the best results.</p>
 <ul>
-<li>Tip: to start UxPlay on a remote host (such as a Raspberry Pi) using
-ssh:</li>
+<li><p><strong>If you are not using the latest patches from the wiki,
+you will also need to add the <code>-bt709</code> option</strong>:
+previously the GStreamer v4l2 plugin could not recognise Apple’s color
+format (an unusual “full-range” variant of the bt709 HDTV standard),
+which -bt709 fixes.</p></li>
+<li><p>Tip: to start UxPlay on a remote host (such as a Raspberry Pi)
+using ssh:</p></li>
 </ul>
 <pre><code>   ssh user@remote_host
    export DISPLAY=:0
@@ -517,13 +516,15 @@ without video in Airplay non-mirror mode.</p>
 <p><strong>-v4l2</strong> Video settings for hardware h264 video
 decoding in the GPU by Video4Linux2. Equivalent to
 <code>-vd v4l2h264dec -vc v4l2convert</code>.</p>
-<p><strong>-bt709</strong> A workaround for the failure of the current
+<p><strong>-bt709</strong> A workaround for the failure of the older
 Video4Linux2 plugin to recognize Apple’s use of an uncommon (but
 permitted) “full-range color” variant of the bt709 color standard for
-digital TV. This will no longer be needed if GStreamer is updated to
-recognize the Apple variant.</p>
-<p><strong>-rpi</strong> Equivalent to “-v4l2 -bt709”. Use for “Desktop”
+digital TV. This is no longer needed by GStreamer-1.20.4 and backports
+from it.</p>
+<p><strong>-rpi</strong> Equivalent to “-v4l2”. Use for “Desktop”
 Raspberry Pi systems with X11.</p>
+<p><strong>-rpigl</strong> Equivalent to “-v4l2 -vs glimagesink”.
+Sometimes better for “Desktop” Raspberry Pi systems with X11.</p>
 <p><strong>-rpifb</strong> Equivalent to “-rpi -vs kmssink” (use for
 Raspberry Pi systems using the framebuffer, like RPi OS Bullseye
 Lite).</p>
@@ -817,6 +818,8 @@ protocol just requires bit 27 (listed as “SupportsLegacyPairing”) of the
 be set. The “features” code and other settings are set in
 <code>UxPlay/lib/dnssdint.h</code>.</p>
 <h1 id="changelog">ChangeLog</h1>
+<p>1.56 2022-07-30 Remove -bt709 from -rpi, -rpiwl, -rpifb as GStreamer
+is now fixed.</p>
 <p>1.55 2022-07-04 Remove the bt709 fix from -v4l2 and create a new
 -bt709 option (previous “-v4l2” is now “-v4l2 -bt709”). This allows the
 currently-required -bt709 option to be used on its own on RPi without

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# UxPlay 1.55:  AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix.
+# UxPlay 1.56:  AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix.
 
 ### Now developed at the GitHub site [https://github.com/FDH2/UxPlay](https://github.com/FDH2/UxPlay) (where all user issues should be posted).
 
@@ -255,17 +255,18 @@ You can also test UxPlay with software-only video decoding using option `-avdec`
 improvements from GStreamer-1.22.   Patches for GStreamer-1.18.4 and later
 are [available with instructions in the UxPlay Wiki](https://github.com/FDH2/UxPlay/wiki/Gstreamer-Video4Linux2-plugin-patches).
 
-* Currently, a workaround implemented in UxPlay-1.55 as the new uxplay option `-bt709` is needed because Apple are using an uncommon "full-range color" variant of the
-"bt709" color standard used for digital TV broadcasting, which is currently not recognized by the Video4Linux2 plugin.  It is planned to eventually add
-support for Apple's variant "bt709" color to GStreamer; after this has been done, this option will no longer be needed (and
-updated patches for backports will be provided in the UxPlay Wiki).
-
-The basic uxplay options for R Pi are ```uxplay -bt709 -v4l2 [-vs <videosink>]```.
+The basic uxplay options for R Pi are ```uxplay -v4l2 [-vs <videosink>]```. The
+choice `<videosink>` = ``glimagesink`` is sometimes useful. 
 On a system without X11 (like R Pi OS Lite) with framebuffer video, use `<videosink>` = ``kmssink``.
 With the  Wayland video compositor (as in  recent Ubuntu for R Pi) use `<videosink>` = ``waylandsink``.  For convenience,
-these options are also available combined in options `-rpi`,``-rpifb``, ```-rpiwl```, respectively
-provided for X11, framebuffer, and Wayland systems. You may find the simple "uxplay -bt709", (which lets GStreamer try to find the best video solution by itself)
+these options are also available combined in options `-rpi`, ``-rpigl``
+``-rpifb``, ```-rpiwl```, respectively provided for X11, X11 with OpenGL, framebuffer, and Wayland systems.
+You may find the simple "uxplay", (which lets GStreamer try to find the best video solution by itself)
 provides the best results.
+
+* **If you are not using the latest patches from the wiki, you will also need to add the `-bt709` option**: previously the GStreamer v4l2 plugin could
+not recognise Apple's color format (an unusual "full-range" variant of the bt709 HDTV standard), which -bt709 fixes.
+
 
 * Tip: to start UxPlay on a remote host (such as a Raspberry Pi) using ssh:
 
@@ -448,11 +449,13 @@ which will not work if a firewall is running.
 **-v4l2** Video settings for hardware h264 video decoding in the GPU by Video4Linux2.  Equivalent to
    `-vd v4l2h264dec -vc v4l2convert`.
 
-**-bt709**  A workaround for the failure of the current Video4Linux2 plugin to recognize Apple's
+**-bt709**  A workaround for the failure of the older  Video4Linux2 plugin to recognize Apple's
    use of an uncommon (but permitted) "full-range color" variant of the bt709 color standard for digital TV.
-   This will no longer be needed if GStreamer is  updated to recognize the Apple variant.
+   This is no longer needed by GStreamer-1.20.4 and backports from it.
 
-**-rpi**  Equivalent to  "-v4l2 -bt709".   Use for "Desktop" Raspberry Pi systems with X11.
+**-rpi**  Equivalent to  "-v4l2 ".   Use for "Desktop" Raspberry Pi systems with X11.
+
+**-rpigl**  Equivalent to  "-v4l2 -vs glimagesink".  Sometimes better for "Desktop" Raspberry Pi systems with X11.
 
 **-rpifb** Equivalent to "-rpi -vs kmssink" (use for Raspberry Pi systems
    using the framebuffer, like RPi OS Bullseye Lite).
@@ -694,6 +697,8 @@ tvOS 12.2.1); it seems that the use of "legacy" protocol just requires bit 27 (l
 The "features" code and other settings are set in `UxPlay/lib/dnssdint.h`.
 
 # ChangeLog
+1.56 2022-07-30   Remove -bt709 from -rpi, -rpiwl, -rpifb as GStreamer is now fixed.
+
 1.55 2022-07-04   Remove the bt709 fix from -v4l2 and  create a new -bt709 option (previous
                   "-v4l2" is now "-v4l2 -bt709").  This allows the currently-required -bt709 
                   option to be used on its own on RPi without -v4l2 (sometimes this give better results). 

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-# UxPlay 1.55: AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix.
+# UxPlay 1.56: AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix.
 
 ### Now developed at the GitHub site <https://github.com/FDH2/UxPlay> (where all user issues should be posted).
 
@@ -283,24 +283,22 @@ options.
     and later are [available with instructions in the UxPlay
     Wiki](https://github.com/FDH2/UxPlay/wiki/Gstreamer-Video4Linux2-plugin-patches).
 
--   Currently, a workaround implemented in UxPlay-1.55 as the new uxplay
-    option `-bt709` is needed because Apple are using an uncommon
-    "full-range color" variant of the "bt709" color standard used for
-    digital TV broadcasting, which is currently not recognized by the
-    Video4Linux2 plugin. It is planned to eventually add support for
-    Apple's variant "bt709" color to GStreamer; after this has been
-    done, this option will no longer be needed (and updated patches for
-    backports will be provided in the UxPlay Wiki).
+The basic uxplay options for R Pi are `uxplay -v4l2 [-vs <videosink>]`.
+The choice `<videosink>` = `glimagesink` is sometimes useful. On a
+system without X11 (like R Pi OS Lite) with framebuffer video, use
+`<videosink>` = `kmssink`. With the Wayland video compositor (as in
+recent Ubuntu for R Pi) use `<videosink>` = `waylandsink`. For
+convenience, these options are also available combined in options
+`-rpi`, `-rpigl` `-rpifb`, `-rpiwl`, respectively provided for X11, X11
+with OpenGL, framebuffer, and Wayland systems. You may find the simple
+"uxplay", (which lets GStreamer try to find the best video solution by
+itself) provides the best results.
 
-The basic uxplay options for R Pi are
-`uxplay -bt709 -v4l2 [-vs <videosink>]`. On a system without X11 (like R
-Pi OS Lite) with framebuffer video, use `<videosink>` = `kmssink`. With
-the Wayland video compositor (as in recent Ubuntu for R Pi) use
-`<videosink>` = `waylandsink`. For convenience, these options are also
-available combined in options `-rpi`,`-rpifb`, `-rpiwl`, respectively
-provided for X11, framebuffer, and Wayland systems. You may find the
-simple "uxplay -bt709", (which lets GStreamer try to find the best video
-solution by itself) provides the best results.
+-   **If you are not using the latest patches from the wiki, you will
+    also need to add the `-bt709` option**: previously the GStreamer
+    v4l2 plugin could not recognise Apple's color format (an unusual
+    "full-range" variant of the bt709 HDTV standard), which -bt709
+    fixes.
 
 -   Tip: to start UxPlay on a remote host (such as a Raspberry Pi) using
     ssh:
@@ -528,14 +526,16 @@ Airplay non-mirror mode.
 **-v4l2** Video settings for hardware h264 video decoding in the GPU by
 Video4Linux2. Equivalent to `-vd v4l2h264dec -vc v4l2convert`.
 
-**-bt709** A workaround for the failure of the current Video4Linux2
-plugin to recognize Apple's use of an uncommon (but permitted)
-"full-range color" variant of the bt709 color standard for digital TV.
-This will no longer be needed if GStreamer is updated to recognize the
-Apple variant.
+**-bt709** A workaround for the failure of the older Video4Linux2 plugin
+to recognize Apple's use of an uncommon (but permitted) "full-range
+color" variant of the bt709 color standard for digital TV. This is no
+longer needed by GStreamer-1.20.4 and backports from it.
 
-**-rpi** Equivalent to "-v4l2 -bt709". Use for "Desktop" Raspberry Pi
-systems with X11.
+**-rpi** Equivalent to "-v4l2". Use for "Desktop" Raspberry Pi systems
+with X11.
+
+**-rpigl** Equivalent to "-v4l2 -vs glimagesink". Sometimes better for
+"Desktop" Raspberry Pi systems with X11.
 
 **-rpifb** Equivalent to "-rpi -vs kmssink" (use for Raspberry Pi
 systems using the framebuffer, like RPi OS Bullseye Lite).
@@ -848,6 +848,9 @@ bit 27 (listed as "SupportsLegacyPairing") of the "features" plist code
 code and other settings are set in `UxPlay/lib/dnssdint.h`.
 
 # ChangeLog
+
+1.56 2022-07-30 Remove -bt709 from -rpi, -rpiwl, -rpifb as GStreamer is
+now fixed.
 
 1.55 2022-07-04 Remove the bt709 fix from -v4l2 and create a new -bt709
 option (previous "-v4l2" is now "-v4l2 -bt709"). This allows the

--- a/uxplay.1
+++ b/uxplay.1
@@ -1,11 +1,11 @@
-.TH UXPLAY "1" "July 2022" "1.55" "User Commands"
+.TH UXPLAY "1" "August 2022" "1.56" "User Commands"
 .SH NAME
 uxplay \- start AirPlay server
 .SH SYNOPSIS
 .B uxplay
 [\fI\,-n name\/\fR] [\fI\,-s wxh\/\fR] [\fI\,-p \/\fR[\fI\,n\/\fR]] [more \fI OPTIONS \/\fR ...]
 .SH DESCRIPTION
-UxPlay 1.55: An open\-source AirPlay mirroring server based on RPiPlay
+UxPlay 1.56: An open\-source AirPlay mirroring server based on RPiPlay
 .SH OPTIONS
 .TP
 .B
@@ -54,9 +54,11 @@ UxPlay 1.55: An open\-source AirPlay mirroring server based on RPiPlay
 .TP
 \fB\-v4l2\fR     Use Video4Linux2 for GPU hardware h264 video decoding.
 .TP
-\fB\-bt709\fR    A workaround (bt709 color) that may be needed with -v4l2.
+\fB\-bt709\fR    A workaround (bt709 color) that may be needed with -rpi.
 .TP
-\fB\-rpi\fR      Same as "-v4l2 -bt709" (for RPi=Rasberry Pi).
+\fB\-rpi\fR      Same as "-v4l2" (for RPi=Rasberry Pi).
+.TP
+\fB\-rpigl\fR    Same as "-v4l2 -vs glimagesink" for RPi.
 .TP
 \fB\-rpifb\fR    Same as "-rpi -vs kmssink" for RPi using framebuffer.
 .TP

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -43,7 +43,7 @@
 #include "renderers/video_renderer.h"
 #include "renderers/audio_renderer.h"
 
-#define VERSION "1.55"
+#define VERSION "1.56"
 
 #define DEFAULT_NAME "UxPlay"
 #define DEFAULT_DEBUG_LOG false
@@ -343,8 +343,9 @@ static void print_info (char *name) {
     printf("          gtksink,waylandsink,osximagesink,kmssink,fpsdisplaysink etc.\n");
     printf("-vs 0     Streamed audio only, with no video display window\n");
     printf("-v4l2     Use Video4Linux2 for GPU hardware h264 decoding\n");
-    printf("-bt709    A workaround (bt709 color) that may be needed with -v4l2\n"); 
-    printf("-rpi      Same as \"-v4l2 -bt709\" (for RPi=Raspberry Pi).\n");
+    printf("-bt709    A workaround (bt709 color) that may be needed with -rpi\n"); 
+    printf("-rpi      Same as \"-v4l2\" (for RPi=Raspberry Pi).\n");
+    printf("-rpigl    Same as \"-rpi -vs glimagesink\" for RPi.\n");
     printf("-rpifb    Same as \"-rpi -vs kmssink\" for RPi using framebuffer.\n");
     printf("-rpiwl    Same as \"-rpi -vs waylandsink\" for RPi using Wayland.\n");
     printf("-as ...   Choose the GStreamer audiosink; default \"autoaudiosink\"\n");
@@ -602,22 +603,30 @@ void parse_arguments (int argc, char *argv[]) {
             video_converter = "videoconvert";
         } else if (arg == "-v4l2" || arg == "-rpi") {
             if (arg == "-rpi") {
-                bt709_fix = true;
+                printf("*** -rpi no longer includes -bt709: add it if needed\n");
             }
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();
             video_converter = "v4l2convert";
         } else if (arg == "-rpifb") {
-            bt709_fix = true;
+            printf("*** -rpifb no longer includes -bt709: add it if needed\n");
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();
             video_converter = "v4l2convert";
             videosink.erase();
             videosink = "kmssink";
+        } else if (arg == "-rpigl") {
+            printf("*** -rpigl does not include -bt709: add it if needed\n");
+            video_decoder.erase();
+            video_decoder = "v4l2h264dec";
+            video_converter.erase();
+            video_converter = "v4l2convert";
+            videosink.erase();
+            videosink = "glimagesink";
         } else if (arg == "-rpiwl" ) {
-            bt709_fix = true;;
+            printf("*** -rpiwl no longer includes -bt709: add it if needed\n");
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();


### PR DESCRIPTION
1.56 2022-07-31 Minor update to revise the Raspberry-Pi-specific "convenience" combined options -rpi*, as GStreamer's Video4Linux2 plugin has been updated to remove the need for the "bt709" color workaround, and updated GStreamer patches are now available. Un-updated GStreamer will now require -bt709 option to be explicitly used. A new convenience option -rpigl for OpenGL graphics on RPi is also added.