### PR TITLE
UxPlay 1.62

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,6 +1,6 @@
 <h1
-id="uxplay-1.61-airplay-mirror-and-airplay-audio-server-for-linux-macos-and-unix-now-also-runs-on-windows.">UxPlay
-1.61: AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix
+id="uxplay-1.62-airplay-mirror-and-airplay-audio-server-for-linux-macos-and-unix-now-also-runs-on-windows.">UxPlay
+1.62: AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix
 (now also runs on Windows).</h1>
 <h3
 id="now-developed-at-the-github-site-httpsgithub.comfdh2uxplay-where-all-user-issues-should-be-posted.">Now
@@ -304,7 +304,8 @@ the dns_sd library. OpenSSL is already installed as a System
 Library.</p></li>
 </ul>
 <h2 id="running-uxplay">Running UxPlay</h2>
-<h3 id="debian-based-systems-1">Debian-based systems</h3>
+<h3 id="installing-plugins-debian-based-linux-systems">Installing
+plugins (Debian-based Linux systems)</h3>
 <p>Next install the GStreamer plugins that are needed with
 <code>sudo apt-get install gstreamer1.0-&lt;plugin&gt;</code>. Values of
 <code>&lt;plugin&gt;</code> required are:</p>
@@ -326,44 +327,8 @@ examining the GStreamer installation. If sound is not working,
 “<strong>alsa</strong>”“,”<strong>pulseaudio</strong>”, or
 “<strong>pipewire</strong>” plugins may need to be installed, depending
 on how your audio is set up.</p>
-<p><strong>Finally, run uxplay in a terminal window</strong>. On some
-systems, you can toggle into and out of fullscreen mode with F11 or
-(held-down left Alt)+Enter keys. Use Ctrl-C (or close the window) to
-terminate it when done. If the UxPlay server is not seen by the iOS
-client’s drop-down “Screen Mirroring” panel, check that your DNS-SD
-server (usually avahi-daemon) is running: do this in a terminal window
-with <code>systemctl status avahi-daemon</code>. If this shows the
-avahi-daemon is not running, control it with
-<code>sudo systemctl [start,stop,enable,disable] avahi-daemon</code> (or
-avahi-daemon.service). If UxPlay is seen, but the client fails to
-connect when it is selected, there may be a firewall on the server that
-prevents UxPlay from receiving client connection requests unless some
-network ports are opened: if a firewall is active, also open UDP port
-5353 (for mDNS queries) needed by Avahi. See <a
-href="#troubleshooting">Troubleshooting</a> below for help with this or
-other problems.</p>
-<ul>
-<li>By default, UxPlay is locked to its current client until that client
-drops the connection; the option <code>-nohold</code> modifies this
-behavior so that when a new client requests a connection, it removes the
-current client and takes over.</li>
-</ul>
-<p>To display the accompanying “Cover Art” from sources like Apple Music
-in Audio-Only (ALAC) mode, run
-“<code>uxplay -ca &lt;name&gt; &amp;</code>” in the background, then run
-a image viewer with an autoreload feature: an example is “feh”: run
-“<code>feh -R 1 &lt;name&gt;</code>” in the foreground; terminate feh
-and then Uxplay with “<code>ctrl-C fg ctrl-C</code>”.</p>
-<p><strong>One common problem involves GStreamer attempting to use
-incorrectly-configured or absent accelerated hardware h264 video
-decoding (e.g., VAAPI). Try “<code>uxplay -avdec</code>” to force
-software video decoding; if this works you can then try to fix
-accelerated hardware video decoding if you need it, or just uninstall
-the GStreamer VAAPI plugin. If your system uses the Wayland compositor
-for graphics, use “<code>uxplay -vs waylandsink</code>”.</strong> See <a
-href="#usage">Usage</a> for more run-time options.</p>
-<h3 id="running-uxplay-non-debian-based-linux-or-bsd">Running uxplay
-Non-Debian-based Linux or *BSD</h3>
+<h3 id="installing-plugins-non-debian-based-linux-or-bsd">Installing
+plugins (Non-Debian-based Linux or *BSD)</h3>
 <ul>
 <li><p><strong>Red Hat, or clones like CentOS (now continued as Rocky
 Linux or Alma Linux):</strong> (sudo dnf install, or sudo yum install)
@@ -396,6 +361,55 @@ gstreamer1-plugins, gstreamer1-plugins-* (* = core, good, bad, x, gtk,
 gl, vulkan, pulse, v4l2, …), (+ gstreamer1-vaapi for Intel
 graphics).</p></li>
 </ul>
+<h3 id="starting-uxplay">Starting UxPlay</h3>
+<p><strong>Finally, run uxplay in a terminal window</strong>. On some
+systems, you can toggle into and out of fullscreen mode with F11 or
+(held-down left Alt)+Enter keys. Use Ctrl-C (or close the window) to
+terminate it when done. If the UxPlay server is not seen by the iOS
+client’s drop-down “Screen Mirroring” panel, check that your DNS-SD
+server (usually avahi-daemon) is running: do this in a terminal window
+with <code>systemctl status avahi-daemon</code>. If this shows the
+avahi-daemon is not running, control it with
+<code>sudo systemctl [start,stop,enable,disable] avahi-daemon</code> (or
+avahi-daemon.service). If UxPlay is seen, but the client fails to
+connect when it is selected, there may be a firewall on the server that
+prevents UxPlay from receiving client connection requests unless some
+network ports are opened: if a firewall is active, also open UDP port
+5353 (for mDNS queries) needed by Avahi. See <a
+href="#troubleshooting">Troubleshooting</a> below for help with this or
+other problems.</p>
+<ul>
+<li><p>By default, UxPlay is locked to its current client until that
+client drops the connection; the option <code>-nohold</code> modifies
+this behavior so that when a new client requests a connection, it
+removes the current client and takes over.</p></li>
+<li><p>To display the accompanying “Cover Art” from sources like Apple
+Music in Audio-Only (ALAC) mode, run
+“<code>uxplay -ca &lt;name&gt; &amp;</code>” in the background, then run
+a image viewer with an autoreload feature: an example is “feh”: run
+“<code>feh -R 1 &lt;name&gt;</code>” in the foreground; terminate feh
+and then Uxplay with “<code>ctrl-C fg ctrl-C</code>”.</p></li>
+<li><p>If you wish to listen in Audio-Only mode on the server while
+watching the client screen (for video or Apple Music song lyrics, etc.),
+the video on the client is delayed by about 5 seconds behind the the
+audio on the server. This can be corrected with the <strong>audio
+offset</strong> option <code>-ao x</code> with an <em>x</em> of about
+5.0 (allowed values of <em>x</em> are decimal numbers between 0 and 10.0
+seconds); this workaround just delays playing of audio on the server by
+<em>x</em> seconds, so the effect of pausing or changing tracks on the
+client will unfortunately also be delayed. <em>(The reason for the 5
+sec. video delay on the client may be because, while streaming in Legacy
+mode, the client does not get latency information from the
+server.)</em></p></li>
+</ul>
+<p><strong>One common problem involves GStreamer attempting to use
+incorrectly-configured or absent accelerated hardware h264 video
+decoding (e.g., VAAPI). Try “<code>uxplay -avdec</code>” to force
+software video decoding; if this works you can then try to fix
+accelerated hardware video decoding if you need it, or just uninstall
+the GStreamer VAAPI plugin. If your system uses the Wayland compositor
+for graphics, use “<code>uxplay -vs waylandsink</code>”.</strong> See <a
+href="#usage">Usage</a> for more run-time options.</p>
 <h3
 id="special-instructions-for-raspberry-pi-only-tested-on-model-4b"><strong>Special
 instructions for Raspberry Pi (only tested on model 4B)</strong>:</h3>
@@ -491,7 +505,7 @@ it, but compiled to use X11).</li>
 </ul>
 <p><strong>For the “official” release</strong>: install both the macOS
 runtime and development installer packages. Assuming that the latest
-release is 1.20.4. install
+release is 1.20.5. install
 <code>gstreamer-1.0-1.20.5-universal.pkg</code> and
 <code>gstreamer-1.0-devel-1.20.5-universal.pkg</code>. (If you have an
 Intel-architecture Mac, and have problems with the “universal” packages,
@@ -753,6 +767,15 @@ parameters to be included with the audiosink name. (Some choices of
 audiosink might not work on your system.)</p>
 <p><strong>-as 0</strong> (or just <strong>-a</strong>) suppresses
 playing of streamed audio, but displays streamed video.</p>
+<p><strong>-ao x.y</strong> adds an audio offset time in (decimal)
+seconds to Audio-only (ALAC) streams to allow synchronization of sound
+playing on the UxPlay server with video on the client. In the AirPlay
+Legacy mode used by UxPlay, the client cannot obtain audio latency
+information from the server, and appears to assume a latency of about 5
+seconds. This can be corrected with offset values such as
+<code>-ao 5</code> or <code>-ao 4.9</code>. The -ao option accepts
+values of the offset between 0 and 10 seconds, as a decimal number which
+it converts to a whole number of milliseconds.</p>
 <p><strong>-ca <em>filename</em></strong> provides a file (where
 <em>filename</em> can include a full path) used for output of “cover
 art” (from Apple Music, <em>etc.</em>,) in audio-only ALAC mode. This
@@ -1055,6 +1078,10 @@ as “SupportsLegacyPairing”) of the “features” plist code (reported to
 the client by the AirPlay server) to be set. The “features” code and
 other settings are set in <code>UxPlay/lib/dnssdint.h</code>.</p>
 <h1 id="changelog">Changelog</h1>
+<p>1.62 2023-01-14 Added Audio-only mode time offset -ao x to allow user
+synchronization of ALAC audio playing on the server with video, song
+lyrics, etc. playing on the client. x = 5.0 appears to be optimal in
+many cases.</p>
 <p>1.61 2022-12-30 Removed -t option (workaround for an Avahi issue,
 correctly solved by opening network port UDP 5353 in firewall). Remove
 -g debug flag from CMAKE_CFLAGS. Postpend (instead of prepend) build

--- a/README.html
+++ b/README.html
@@ -382,6 +382,10 @@ queries) needed by Avahi. See <a
 href="#troubleshooting">Troubleshooting</a> below for help with this or
 other problems.</p>
 <ul>
+<li><p>you may find video is improved by the setting -fps 60 that allows
+some video to be played at 60 frames per second. (You can see what
+framerate is actually streaming by using -vs fpsdisplaysink, and/or
+-FPSdata.)</p></li>
 <li><p>By default, UxPlay is locked to its current client until that
 client drops the connection; the option <code>-nohold</code> modifies
 this behavior so that when a new client requests a connection, it
@@ -818,14 +822,15 @@ data is updated by the client at 1 second intervals.</p>
 <p><strong>-fps n</strong> sets a maximum frame rate (in frames per
 second) for the AirPlay client to stream video; n must be a whole number
 less than 256. (The client may choose to serve video at any frame rate
-lower than this; default is 60 fps.) A setting below 60 fps might be
-useful to reduce latency if you are running more than one instance of
-uxplay at the same time. <em>This setting is only an advisory to the
-client device, so setting a high value will not force a high
-framerate.</em> (You can test using “-vs fpsdisplaysink” to see what
-framerate is being received, or use the option -FPSdata which displays
-video-stream performance data continuously sent by the client during
-video-streaming.)</p>
+lower than this; default is 30 fps.) A setting of 60 fps may give you
+improved video but is not recommended on Raspberry Pi. A setting below
+30 fps might be useful to reduce latency if you are running more than
+one instance of uxplay at the same time. <em>This setting is only an
+advisory to the client device, so setting a high value will not force a
+high framerate.</em> (You can test using “-vs fpsdisplaysink” to see
+what framerate is being received, or use the option -FPSdata which
+displays video-stream performance data continuously sent by the client
+during video-streaming.)</p>
 <p><strong>-f {H|V|I}</strong> implements “videoflip” image transforms:
 H = horizontal flip (right-left flip, or mirror image); V = vertical
 flip ; I = 180 degree rotation or inversion (which is the combination of
@@ -1098,8 +1103,8 @@ other settings are set in <code>UxPlay/lib/dnssdint.h</code>.</p>
 <p>1.62 2023-01-18 Added Audio-only mode time offset -ao x to allow user
 synchronization of ALAC audio playing on the server with video, song
 lyrics, etc. playing on the client. x = 5.0 appears to be optimal in
-many cases. Quality fixes: change default fps to 60, cleanup in volume
-changes, timestamps, some bugfixes.</p>
+many cases. Quality fixes: cleanup in volume changes, timestamps, some
+bugfixes.</p>
 <p>1.61 2022-12-30 Removed -t option (workaround for an Avahi issue,
 correctly solved by opening network port UDP 5353 in firewall). Remove
 -g debug flag from CMAKE_CFLAGS. Postpend (instead of prepend) build

--- a/README.html
+++ b/README.html
@@ -815,7 +815,7 @@ data is updated by the client at 1 second intervals.</p>
 <p><strong>-fps n</strong> sets a maximum frame rate (in frames per
 second) for the AirPlay client to stream video; n must be a whole number
 less than 256. (The client may choose to serve video at any frame rate
-lower than this; default is 30 fps.) A setting below 30 fps might be
+lower than this; default is 60 fps.) A setting below 60 fps might be
 useful to reduce latency if you are running more than one instance of
 uxplay at the same time. <em>This setting is only an advisory to the
 client device, so setting a high value will not force a high

--- a/README.html
+++ b/README.html
@@ -60,18 +60,20 @@ binary package, you may need to read the instructions below for <a
 href="#running-uxplay">running UxPlay</a> to see which of your
 distribution’s <strong>GStreamer plugin packages</strong> you should
 also install.</p></li>
-<li><p>For Raspbery Pi (tested on RPi 4 model B, reported to work on RPi
-3 model B+), only Raspberry Pi OS, plus the Debian and Manjaro ARM-RPi4
-Images made available through the Raspberry Pi Imager, are known to
-provide the (out-of-mainline-kernel) kernel-module
-<strong>bcm2835-codec.ko</strong> maintained by Rasperry Pi, and needed
-for hardware-accelerated video decoding by the Broadcom GPU on the Pi,
-accessed using the GStreamer Video4Linux (v4l2) plugin. In addition, for
-Ubuntu and Manjaro, the v4l2 plugin needs a <a
+<li><p>For Raspberry Pi (tested on RPi 4 model B, reported to work on
+RPi 3 model B+), only Raspberry Pi OS, plus the Debian and Manjaro
+ARM-RPi4 Images made available through the Raspberry Pi Imager, are
+known to provide the (out-of-mainline-kernel) kernel-module
+<strong>bcm2835-codec.ko</strong> <a
+href="https://github.com/raspberrypi/linux/tree/rpi-5.15.y/drivers/staging/vc04_services">maintained
+by Raspberry Pi</a>, and needed for hardware-accelerated video decoding
+by the Broadcom GPU on the Pi, accessed using the GStreamer Video4Linux
+(v4l2) plugin. In addition, for Ubuntu and Manjaro, the v4l2 plugin
+needs a <a
 href="https://github.com/FDH2/UxPlay/wiki/Gstreamer-Video4Linux2-plugin-patches">patch</a>
 forGStreamer &lt; 1.22.</p></li>
 <li><p>To (easily) compile UxPlay from source, see the section <a
-href="#building-uxplay">building UxPlay</a>.</p></li>
+href="#getting-uxplay">Getting UxPlay</a>.</p></li>
 </ul>
 <h1 id="detailed-description-of-uxplay">Detailed description of
 UxPlay</h1>

--- a/README.html
+++ b/README.html
@@ -370,12 +370,14 @@ client’s drop-down “Screen Mirroring” panel, check that your DNS-SD
 server (usually avahi-daemon) is running: do this in a terminal window
 with <code>systemctl status avahi-daemon</code>. If this shows the
 avahi-daemon is not running, control it with
-<code>sudo systemctl [start,stop,enable,disable] avahi-daemon</code> (or
-avahi-daemon.service). If UxPlay is seen, but the client fails to
-connect when it is selected, there may be a firewall on the server that
-prevents UxPlay from receiving client connection requests unless some
-network ports are opened: if a firewall is active, also open UDP port
-5353 (for mDNS queries) needed by Avahi. See <a
+<code>sudo systemctl [start,stop,enable,disable] avahi-daemon</code> (on
+non-systemd systems, such as *BSD, use
+<code>sudo service avahi-daemon [status, start, stop, restart, ...]</code>).
+If UxPlay is seen, but the client fails to connect when it is selected,
+there may be a firewall on the server that prevents UxPlay from
+receiving client connection requests unless some network ports are
+opened: if a firewall is active, also open UDP port 5353 (for mDNS
+queries) needed by Avahi. See <a
 href="#troubleshooting">Troubleshooting</a> below for help with this or
 other problems.</p>
 <ul>

--- a/README.html
+++ b/README.html
@@ -234,11 +234,12 @@ that cmake&gt;=3.4.1 is installed:
 <code>build-essential</code> and <code>pkg-config</code> (or
 <code>pkgconf</code>) to this if needed).</p>
 <p>Make sure that your distribution provides OpenSSL 1.1.1 or later, and
-libplist 2.0 or later. (This means Debian 10 “Buster”, Ubuntu 18.04 or
-later.) If it does not, you may need to build and install these from
-source (see instructions at the end of this README). If you have a
-non-standard OpenSSL installation, you may need to set the environment
-variable OPENSSL_ROOT_DIR (<em>e.g.</em> ,
+libplist 2.0 or later. (This means Debian 10 “Buster” based systems
+(e.g, Ubuntu 18.04) or newer; on Debian 10 systems “libplist” is an
+older version, you need “libplist3”.) If it does not, you may need to
+build and install these from source (see instructions at the end of this
+README). If you have a non-standard OpenSSL installation, you may need
+to set the environment variable OPENSSL_ROOT_DIR (<em>e.g.</em> ,
 “<code>export OPENSSL_ROOT_DIR=/usr/local/lib64</code>” if that is where
 it is installed).</p>
 <p>In a terminal window, change directories to the source directory of
@@ -348,8 +349,8 @@ start, with error: <strong>no element “avdec_aac”</strong>
 <li><p><strong>OpenSUSE:</strong> (sudo zypper install) The required
 GStreamer packages are: gstreamer-devel gstreamer-plugins-base-devel
 gstreamer-plugins-libav gstreamer-plugins-bad (+ gstreamer-plugins-vaapi
-for Intel graphics); in some cases, you may need to use gstreamer
-packages for OpenSUSE from <a
+for Intel graphics); in some cases, you may need to use gstreamer or
+libav* packages for OpenSUSE from <a
 href="https://ftp.gwdg.de/pub/linux/misc/packman/suse/">Packman</a>
 “Essentials” (which provides packages including plugins that OpenSUSE
 does not ship for license reasons).</p></li>
@@ -771,13 +772,15 @@ audiosink might not work on your system.)</p>
 playing of streamed audio, but displays streamed video.</p>
 <p><strong>-ao x.y</strong> adds an audio offset time in (decimal)
 seconds to Audio-only (ALAC) streams to allow synchronization of sound
-playing on the UxPlay server with video on the client. In the AirPlay
-Legacy mode used by UxPlay, the client cannot obtain audio latency
-information from the server, and appears to assume a latency of about 5
-seconds. This can be corrected with offset values such as
-<code>-ao 5</code> or <code>-ao 4.9</code>. The -ao option accepts
-values of the offset between 0 and 10 seconds, as a decimal number which
-it converts to a whole number of milliseconds.</p>
+playing on the UxPlay server with video on the client which delays
+playing the audio by <em>x.y</em> seconds (a decimal number). In the
+AirPlay Legacy mode used by UxPlay, the client cannot obtain audio
+latency information from the server, and appears to assume a latency of
+about 5 seconds. This can be compensated for with offset values such as
+<code>-ao 5</code> (but the effect of a pause in play etc., on the
+client will also be delayed). The -ao option accepts values in the range
+[0,10], which it converts to a whole number of milliseconds (-ao 1.2345
+gives 1234 msec audio delay).</p>
 <p><strong>-ca <em>filename</em></strong> provides a file (where
 <em>filename</em> can include a full path) used for output of “cover
 art” (from Apple Music, <em>etc.</em>,) in audio-only ALAC mode. This
@@ -875,11 +878,13 @@ present, set the environment variable OPEN_SSL_ROOT_DIR to point to the
 correct one; on 64-bit Ubuntu, this is done by running
 <code>export OPENSSL_ROOT_DIR=/usr/lib/X86_64-linux-gnu/</code> before
 running cmake.</p>
-<h3
-id="uxplay-starts-but-either-stalls-or-stops-after-initialized-server-sockets-appears-without-the-server-name-showing-on-the-client.">1.
-uxplay starts, but either stalls or stops after “Initialized server
-socket(s)” appears (<em>without the server name showing on the
-client</em>).</h3>
+<h3 id="avahidns_sd-bonjourzeroconf-issues">1. <strong>Avahi/DNS_SD
+Bonjour/Zeroconf issues</strong></h3>
+<ul>
+<li><strong>uxplay starts, but either stalls or stops after “Initialized
+server socket(s)” appears (<em>without the server name showing on the
+client</em>)</strong>.</li>
+</ul>
 <p>If UxPlay stops with the “No DNS-SD Server found” message, this means
 that your network <strong>does not have a running Bonjour/zeroconf
 DNS-SD server.</strong></p>
@@ -910,11 +915,21 @@ for airplay support.</em>)</p>
 <p>If UxPlay stalls <em>without an error message</em> and <em>without
 the server name showing on the client</em>, this is either
 pre-UxPlay-1.60 behavior when no DNS-SD server was found, or a network
-problem. After starting uxplay, use the utility
+problem.</p>
+<ul>
+<li><strong>Avahi works at first, but new clients do not see UxPlay, or
+clients that initially saw it stop doing so after they
+disconnect</strong>.</li>
+</ul>
+<p>This is because Avahi is only using the “loopback” network interface,
+and is not receiving mDNS queries from new clients that were not
+listening when UxPlay started.</p>
+<p>To check this, after starting uxplay, use the utility
 <code>avahi-browse -a -t</code> in a different terminal window on the
 server to verify that the UxPlay AirTunes and AirPlay services are
 correctly registered (only the AirTunes service is used in the “Legacy”
-AirPlay Mirror mode used by UxPlay).</p>
+AirPlay Mirror mode used by UxPlay, bit the AirPlay service is used for
+the initial contact).</p>
 <p>The results returned by avahi-browse should show entries for uxplay
 like</p>
 <pre><code>+   eno1 IPv6 UxPlay                                        AirPlay Remote Video local
@@ -928,9 +943,9 @@ like</p>
 UxPlay host is probably blocking full DNS-SD service, and you need to
 open the default UDP port 5353 for mDNS requests, as loopback-based
 DNS-SD service is unreliable.</p>
-<p>If the UxPlay service is listed by avahi-browse, but is not seen by
-the client, the problem is likely to be a problem with the local
-network.</p>
+<p>If the UxPlay services are listed by avahi-browse as above, but are
+not seen by the client, the problem is likely to be a problem with the
+local network.</p>
 <h3
 id="uxplay-starts-but-stalls-after-initialized-server-sockets-appears-with-the-server-name-showing-on-the-client-but-the-client-fails-to-connect-when-the-uxplay-server-is-selected.">2.
 uxplay starts, but stalls after “Initialized server socket(s)” appears,
@@ -1080,11 +1095,11 @@ as “SupportsLegacyPairing”) of the “features” plist code (reported to
 the client by the AirPlay server) to be set. The “features” code and
 other settings are set in <code>UxPlay/lib/dnssdint.h</code>.</p>
 <h1 id="changelog">Changelog</h1>
-<p>1.62 2023-01-14 Added Audio-only mode time offset -ao x to allow user
+<p>1.62 2023-01-18 Added Audio-only mode time offset -ao x to allow user
 synchronization of ALAC audio playing on the server with video, song
 lyrics, etc. playing on the client. x = 5.0 appears to be optimal in
 many cases. Quality fixes: change default fps to 60, cleanup in volume
-changes, some bugfixes.</p>
+changes, timestamps, some bugfixes.</p>
 <p>1.61 2022-12-30 Removed -t option (workaround for an Avahi issue,
 correctly solved by opening network port UDP 5353 in firewall). Remove
 -g debug flag from CMAKE_CFLAGS. Postpend (instead of prepend) build

--- a/README.html
+++ b/README.html
@@ -1083,7 +1083,8 @@ other settings are set in <code>UxPlay/lib/dnssdint.h</code>.</p>
 <p>1.62 2023-01-14 Added Audio-only mode time offset -ao x to allow user
 synchronization of ALAC audio playing on the server with video, song
 lyrics, etc. playing on the client. x = 5.0 appears to be optimal in
-many cases.</p>
+many cases. Quality fixes: change default fps to 60, cleanup in volume
+changes, some bugfixes.</p>
 <p>1.61 2022-12-30 Removed -t option (workaround for an Avahi issue,
 correctly solved by opening network port UDP 5353 in firewall). Remove
 -g debug flag from CMAKE_CFLAGS. Postpend (instead of prepend) build

--- a/README.md
+++ b/README.md
@@ -324,6 +324,9 @@ are opened: if a firewall is active, also open UDP port 5353 (for mDNS queries)
 needed by Avahi. See [Troubleshooting](#troubleshooting) below for
 help with this or other problems.
 
+* you may find video is improved by the setting -fps 60 that allows some video to be played at 60 frames
+per second. (You can see what framerate is actually streaming by using -vs fpsdisplaysink, and/or -FPSdata.)
+
 * By default, UxPlay is locked to
 its current client until that client drops the connection; the option `-nohold` modifies this
 behavior so that when a new client requests a connection, it removes the current client and takes over.
@@ -692,7 +695,8 @@ which will not work if a firewall is running.
 **-fps n** sets a maximum frame rate (in frames per second) for the AirPlay
    client to stream video; n must be a whole number less than 256.
    (The client may choose to serve video at any frame rate lower
-   than this;  default is 60 fps.)  A setting below 60 fps might be useful to
+   than this;  default is 30 fps.)  A setting of 60 fps may give you improved video
+   but is not recommended on Raspberry Pi.   A setting below 30 fps might be useful to
    reduce latency if you are running more than one instance of uxplay at the same time.
    _This setting is only an advisory to
    the client device, so setting a high value will not force a high framerate._
@@ -922,8 +926,8 @@ The "features" code and other settings are set in `UxPlay/lib/dnssdint.h`.
 # Changelog
 1.62 2023-01-18   Added Audio-only mode time offset -ao x to allow user synchronization of ALAC
                   audio playing on the server with video, song lyrics, etc. playing on the client.
-                  x = 5.0 appears to be optimal in many cases.  Quality fixes: change default fps to 60,
-                  cleanup in volume changes, timestamps, some bugfixes.
+                  x = 5.0 appears to be optimal in many cases.  Quality fixes: cleanup in volume 
+                  changes, timestamps, some bugfixes.
 
 1.61 2022-12-30   Removed -t option (workaround for an Avahi issue, correctly solved by opening network
                   port UDP 5353 in firewall).  Remove -g debug flag from CMAKE_CFLAGS. Postpend (instead 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,21 @@
 * Install uxplay on Debian-based Linux systems with "`sudo apt install uxplay`"; on FreeBSD with "``sudo pkg install uxplay``".
 
 * On Linux and  \*BSD the mDNS/DNS-SD (Bonjour/ZeroConf) local network services needed by UxPlay are usually provided by Avahi: **if
-there is a firewall on the server that will host UxPlay, make sure the default network port for mDNS queries (UDP 5353) is open**. (Uxplay can work without this port by using
-only the host's loopback interface, but its visibility to clients will be degraded.)  See the [Troubleshooting](#troubleshooting) section below for more details.
+there is a firewall on the server that will host UxPlay, make sure the default network port for mDNS queries (UDP 5353) is open**. (Uxplay
+can work without this port by using only the host's loopback interface, but its visibility to clients will be
+degraded.)  See the [Troubleshooting](#troubleshooting) section below for more details.
 
 * Even if you install your distribution's pre-compiled uxplay binary package, you may need to read the instructions below
 for [running UxPlay](#running-uxplay) to see which of your distribution's **GStreamer plugin packages** you should also install.
 
-* For Raspbery Pi (tested on RPi 4 model B, reported to work on RPi 3 model B+), only Raspberry Pi OS, plus the Debian and Manjaro ARM-RPi4 Images made available through the Raspberry Pi Imager, are known to provide the (out-of-mainline-kernel)
-kernel-module **bcm2835-codec.ko** maintained by Rasperry Pi, and needed for hardware-accelerated video decoding by the Broadcom GPU on the Pi, accessed using the GStreamer Video4Linux (v4l2) plugin.   In addition,
+* For Raspberry Pi (tested on RPi 4 model B, reported to work on RPi 3 model B+), only Raspberry Pi OS, plus the Debian
+and Manjaro ARM-RPi4 Images made available through the Raspberry Pi Imager, are known to provide the (out-of-mainline-kernel)
+kernel-module **bcm2835-codec.ko** [maintained by Raspberry Pi](https://github.com/raspberrypi/linux/tree/rpi-5.15.y/drivers/staging/vc04_services),
+and needed for hardware-accelerated video decoding by
+the Broadcom GPU on the Pi, accessed using the GStreamer Video4Linux (v4l2) plugin.   In addition,
 for Ubuntu and Manjaro, the v4l2 plugin needs a [patch](https://github.com/FDH2/UxPlay/wiki/Gstreamer-Video4Linux2-plugin-patches) forGStreamer < 1.22.
 
-* To (easily) compile UxPlay from source, see the section [building UxPlay](#building-uxplay).
+* To (easily) compile UxPlay from source, see the section [Getting UxPlay](#getting-uxplay).
 
 # Detailed description of UxPlay
 

--- a/README.md
+++ b/README.md
@@ -912,7 +912,8 @@ The "features" code and other settings are set in `UxPlay/lib/dnssdint.h`.
 # Changelog
 1.62 2023-01-14   Added Audio-only mode time offset -ao x to allow user synchronization of ALAC
                   audio playing on the server with video, song lyrics, etc. playing on the client.
-                  x = 5.0 appears to be optimal in many cases.
+                  x = 5.0 appears to be optimal in many cases.  Quality fixes: change default fps to 60,
+                  cleanup in volume changes, some bugfixes.
 
 1.61 2022-12-30   Removed -t option (workaround for an Avahi issue, correctly solved by opening network
                   port UDP 5353 in firewall).  Remove -g debug flag from CMAKE_CFLAGS. Postpend (instead 

--- a/README.md
+++ b/README.md
@@ -314,9 +314,10 @@ iOS client's drop-down "Screen Mirroring" panel, check that your DNS-SD
 server (usually avahi-daemon) is running: do this in a terminal window
 with ```systemctl status avahi-daemon```.
 If this shows the avahi-daemon is not running, control it
-with ```sudo systemctl [start,stop,enable,disable] avahi-daemon``` (or
-avahi-daemon.service). If UxPlay is seen, but the client fails to connect
-when it is selected, there may be a firewall on the server that  prevents
+with ```sudo systemctl [start,stop,enable,disable] avahi-daemon``` (on non-systemd systems, such as  \*BSD,
+use ``sudo service avahi-daemon [status, start, stop, restart, ...]``). If UxPlay is
+seen, but the client fails to connect
+when it is selected, there may be a firewall on the server that prevents
 UxPlay from receiving client connection requests unless some network ports
 are opened: if a firewall is active, also open UDP port 5353 (for mDNS queries)
 needed by Avahi. See [Troubleshooting](#troubleshooting) below for

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# UxPlay 1.61:  AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix (now also runs on Windows).
+# UxPlay 1.62:  AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix (now also runs on Windows).
 
 ### Now developed at the GitHub site [https://github.com/FDH2/UxPlay](https://github.com/FDH2/UxPlay) (where all user issues should be posted).
 
@@ -255,7 +255,7 @@ OpenSSL is already installed as a System Library.
 
 ## Running UxPlay
 
-### Debian-based systems
+### Installing plugins (Debian-based Linux systems)
 
 Next install the GStreamer plugins that are needed with `sudo apt-get install gstreamer1.0-<plugin>`.
 Values of `<plugin>` required are: 
@@ -274,41 +274,8 @@ Also install "**tools**" to get the utility gst-inspect-1.0 for
 examining the GStreamer installation.  If sound is not working, "**alsa**"", "**pulseaudio**",
 or "**pipewire**" plugins may need to be installed, depending on how your audio is set up.
 
-**Finally, run uxplay in a terminal window**. On some systems, you can toggle into and out of fullscreen mode
-with F11 or (held-down left Alt)+Enter keys.  Use Ctrl-C (or close the window)
-to terminate it when done. If the UxPlay server is not seen by the
-iOS client's drop-down "Screen Mirroring" panel, check that your DNS-SD
-server (usually avahi-daemon) is running: do this in a terminal window
-with ```systemctl status avahi-daemon```.
-If this shows the avahi-daemon is not running, control it
-with ```sudo systemctl [start,stop,enable,disable] avahi-daemon``` (or
-avahi-daemon.service). If UxPlay is seen, but the client fails to connect
-when it is selected, there may be a firewall on the server that  prevents
-UxPlay from receiving client connection requests unless some network ports
-are opened: if a firewall is active, also open UDP port 5353 (for mDNS queries)
-needed by Avahi. See [Troubleshooting](#troubleshooting) below for
-help with this or other problems.
 
-* By default, UxPlay is locked to
-its current client until that client drops the connection; the option `-nohold` modifies this
-behavior so that when a new client requests a connection, it removes the current client and takes over.
-
-To display the accompanying "Cover Art" from sources like Apple Music in Audio-Only (ALAC) mode,
-run "`uxplay -ca <name> &`" in the background, then run a image viewer with an autoreload feature: an example
-is "feh": run "``feh -R 1 <name>``"
-in the foreground; terminate feh and then Uxplay with "`ctrl-C fg ctrl-C`".
-
-
-**One common problem involves GStreamer
-attempting to use incorrectly-configured or absent accelerated hardware h264
-video decoding (e.g., VAAPI).
-Try "`uxplay -avdec`" to force software video decoding; if this works you can
-then try to fix accelerated hardware video decoding if you need it, or just uninstall the GStreamer VAAPI plugin. If
-your system uses the Wayland compositor for graphics, use "`uxplay -vs waylandsink`".**
-See [Usage](#usage) for more run-time options.
-
-
-### Running uxplay Non-Debian-based Linux or \*BSD
+### Installing plugins (Non-Debian-based Linux or \*BSD)
 
 * **Red Hat, or clones like CentOS (now continued as Rocky Linux or Alma Linux):** 
 (sudo dnf install, or sudo yum install) The required GStreamer packages are:
@@ -337,6 +304,48 @@ for Intel graphics).
  * **FreeBSD:** (sudo pkg install)  gstreamer1-libav, gstreamer1-plugins, gstreamer1-plugins-*
 (\* = core, good,  bad, x, gtk, gl, vulkan, pulse, v4l2,  ...), (+ gstreamer1-vaapi for Intel graphics).
 
+
+### Starting UxPlay 
+
+**Finally, run uxplay in a terminal window**. On some systems, you can toggle into and out of fullscreen mode
+with F11 or (held-down left Alt)+Enter keys.  Use Ctrl-C (or close the window)
+to terminate it when done. If the UxPlay server is not seen by the
+iOS client's drop-down "Screen Mirroring" panel, check that your DNS-SD
+server (usually avahi-daemon) is running: do this in a terminal window
+with ```systemctl status avahi-daemon```.
+If this shows the avahi-daemon is not running, control it
+with ```sudo systemctl [start,stop,enable,disable] avahi-daemon``` (or
+avahi-daemon.service). If UxPlay is seen, but the client fails to connect
+when it is selected, there may be a firewall on the server that  prevents
+UxPlay from receiving client connection requests unless some network ports
+are opened: if a firewall is active, also open UDP port 5353 (for mDNS queries)
+needed by Avahi. See [Troubleshooting](#troubleshooting) below for
+help with this or other problems.
+
+* By default, UxPlay is locked to
+its current client until that client drops the connection; the option `-nohold` modifies this
+behavior so that when a new client requests a connection, it removes the current client and takes over.
+
+* To display the accompanying "Cover Art" from sources like Apple Music in Audio-Only (ALAC) mode,
+run "`uxplay -ca <name> &`" in the background, then run a image viewer with an autoreload feature: an example
+is "feh": run "``feh -R 1 <name>``"
+in the foreground; terminate feh and then Uxplay with "`ctrl-C fg ctrl-C`".
+
+* If you wish to listen in Audio-Only mode on the server while watching the client screen (for video or Apple Music song lyrics, etc.),
+the video on the client is delayed by about 5 seconds behind the the audio on the server.  This can be corrected with
+the **audio offset** option `-ao x` with an _x_ of about 5.0
+(allowed values of _x_ are decimal numbers between 0 and 10.0 seconds); this workaround just delays playing of audio on the server by _x_ seconds, so the effect
+of pausing or changing tracks on the client will unfortunately also be delayed.    _(The reason for the 5 sec.  video delay on the client
+may be because, while streaming in Legacy mode, the client does not get latency information from the
+server.)_
+
+**One common problem involves GStreamer
+attempting to use incorrectly-configured or absent accelerated hardware h264
+video decoding (e.g., VAAPI).
+Try "`uxplay -avdec`" to force software video decoding; if this works you can
+then try to fix accelerated hardware video decoding if you need it, or just uninstall the GStreamer VAAPI plugin. If
+your system uses the Wayland compositor for graphics, use "`uxplay -vs waylandsink`".**
+See [Usage](#usage) for more run-time options.
 
 
 ### **Special instructions for Raspberry Pi (only tested on model 4B)**:
@@ -411,7 +420,7 @@ Next get the latest macOS release of GStreamer-1.0.
 from [https://gstreamer.freedesktop.org/download/](https://gstreamer.freedesktop.org/download/).  The alternative is to install it from Homebrew
 (MacPorts also supplies it, but compiled to use X11).
 
-**For the "official" release**: install both the macOS runtime and development installer packages. Assuming that the latest release is 1.20.4.
+**For the "official" release**: install both the macOS runtime and development installer packages. Assuming that the latest release is 1.20.5.
 install `gstreamer-1.0-1.20.5-universal.pkg` and ``gstreamer-1.0-devel-1.20.5-universal.pkg``.  (If
 you have an Intel-architecture Mac, and  have problems with the "universal" packages, you can also
 use `gstreamer-1.0-1.18.6-x86_64.pkg` and ``gstreamer-1.0-devel-1.18.6-x86_64.pkg``.)   Click on them to
@@ -645,6 +654,12 @@ which will not work if a firewall is running.
    (Some choices of audiosink might not work on your system.)   
 
 **-as 0**  (or just **-a**) suppresses playing of streamed audio, but displays streamed video.
+
+**-ao x.y** adds an audio offset time in (decimal) seconds to Audio-only (ALAC) streams to allow synchronization of sound
+   playing on the UxPlay server with video on the client.  In the AirPlay Legacy mode used by UxPlay, the client cannot
+   obtain audio latency information from the server, and appears to assume a latency of about 5 seconds.  This can be corrected
+   with offset values such as `-ao 5` or ``-ao 4.9``.   The -ao option accepts values of the offset between 0 and 10 seconds, as
+   a decimal number which it converts to a whole number of milliseconds.
 
 **-ca _filename_** provides a file (where _filename_ can include a full path) used for output of "cover art"
    (from Apple Music, _etc._,) in audio-only ALAC mode.   This file is overwritten with the latest cover art as
@@ -894,6 +909,10 @@ tvOS 12.2.1); it seems that the use of "legacy" protocol just requires bit 27 (l
 The "features" code and other settings are set in `UxPlay/lib/dnssdint.h`.
 
 # Changelog
+1.62 2023-01-14   Added Audio-only mode time offset -ao x to allow user synchronization of ALAC
+                  audio playing on the server with video, song lyrics, etc. playing on the client.
+                  x = 5.0 appears to be optimal in many cases.
+
 1.61 2022-12-30   Removed -t option (workaround for an Avahi issue, correctly solved by opening network
                   port UDP 5353 in firewall).  Remove -g debug flag from CMAKE_CFLAGS. Postpend (instead 
                   of prepend) build environment CFLAGS to CMAKE_CFLAGS.  Refactor parts of uxplay.cpp

--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ which will not work if a firewall is running.
 **-fps n** sets a maximum frame rate (in frames per second) for the AirPlay
    client to stream video; n must be a whole number less than 256.
    (The client may choose to serve video at any frame rate lower
-   than this;  default is 30 fps.)  A setting below 30 fps might be useful to
+   than this;  default is 60 fps.)  A setting below 60 fps might be useful to
    reduce latency if you are running more than one instance of uxplay at the same time.
    _This setting is only an advisory to
    the client device, so setting a high value will not force a high framerate._

--- a/README.txt
+++ b/README.txt
@@ -384,6 +384,11 @@ opened: if a firewall is active, also open UDP port 5353 (for mDNS
 queries) needed by Avahi. See [Troubleshooting](#troubleshooting) below
 for help with this or other problems.
 
+-   you may find video is improved by the setting -fps 60 that allows
+    some video to be played at 60 frames per second. (You can see what
+    framerate is actually streaming by using -vs fpsdisplaysink, and/or
+    -FPSdata.)
+
 -   By default, UxPlay is locked to its current client until that client
     drops the connection; the option `-nohold` modifies this behavior so
     that when a new client requests a connection, it removes the current
@@ -842,13 +847,15 @@ updated by the client at 1 second intervals.
 **-fps n** sets a maximum frame rate (in frames per second) for the
 AirPlay client to stream video; n must be a whole number less than 256.
 (The client may choose to serve video at any frame rate lower than this;
-default is 60 fps.) A setting below 60 fps might be useful to reduce
-latency if you are running more than one instance of uxplay at the same
-time. *This setting is only an advisory to the client device, so setting
-a high value will not force a high framerate.* (You can test using "-vs
-fpsdisplaysink" to see what framerate is being received, or use the
-option -FPSdata which displays video-stream performance data
-continuously sent by the client during video-streaming.)
+default is 30 fps.) A setting of 60 fps may give you improved video but
+is not recommended on Raspberry Pi. A setting below 30 fps might be
+useful to reduce latency if you are running more than one instance of
+uxplay at the same time. *This setting is only an advisory to the client
+device, so setting a high value will not force a high framerate.* (You
+can test using "-vs fpsdisplaysink" to see what framerate is being
+received, or use the option -FPSdata which displays video-stream
+performance data continuously sent by the client during
+video-streaming.)
 
 **-f {H\|V\|I}** implements "videoflip" image transforms: H = horizontal
 flip (right-left flip, or mirror image); V = vertical flip ; I = 180
@@ -1140,8 +1147,8 @@ other settings are set in `UxPlay/lib/dnssdint.h`.
 1.62 2023-01-18 Added Audio-only mode time offset -ao x to allow user
 synchronization of ALAC audio playing on the server with video, song
 lyrics, etc. playing on the client. x = 5.0 appears to be optimal in
-many cases. Quality fixes: change default fps to 60, cleanup in volume
-changes, timestamps, some bugfixes.
+many cases. Quality fixes: cleanup in volume changes, timestamps, some
+bugfixes.
 
 1.61 2022-12-30 Removed -t option (workaround for an Avahi issue,
 correctly solved by opening network port UDP 5353 in firewall). Remove

--- a/README.txt
+++ b/README.txt
@@ -60,19 +60,20 @@ status](https://repology.org/badge/vertical-allrepos/uxplay.svg)](https://repolo
     UxPlay](#running-uxplay) to see which of your distribution's
     **GStreamer plugin packages** you should also install.
 
--   For Raspbery Pi (tested on RPi 4 model B, reported to work on RPi 3
+-   For Raspberry Pi (tested on RPi 4 model B, reported to work on RPi 3
     model B+), only Raspberry Pi OS, plus the Debian and Manjaro
     ARM-RPi4 Images made available through the Raspberry Pi Imager, are
     known to provide the (out-of-mainline-kernel) kernel-module
-    **bcm2835-codec.ko** maintained by Rasperry Pi, and needed for
-    hardware-accelerated video decoding by the Broadcom GPU on the Pi,
-    accessed using the GStreamer Video4Linux (v4l2) plugin. In addition,
-    for Ubuntu and Manjaro, the v4l2 plugin needs a
+    **bcm2835-codec.ko** [maintained by Raspberry
+    Pi](https://github.com/raspberrypi/linux/tree/rpi-5.15.y/drivers/staging/vc04_services),
+    and needed for hardware-accelerated video decoding by the Broadcom
+    GPU on the Pi, accessed using the GStreamer Video4Linux (v4l2)
+    plugin. In addition, for Ubuntu and Manjaro, the v4l2 plugin needs a
     [patch](https://github.com/FDH2/UxPlay/wiki/Gstreamer-Video4Linux2-plugin-patches)
     forGStreamer \< 1.22.
 
--   To (easily) compile UxPlay from source, see the section [building
-    UxPlay](#building-uxplay).
+-   To (easily) compile UxPlay from source, see the section [Getting
+    UxPlay](#getting-uxplay).
 
 # Detailed description of UxPlay
 

--- a/README.txt
+++ b/README.txt
@@ -839,7 +839,7 @@ updated by the client at 1 second intervals.
 **-fps n** sets a maximum frame rate (in frames per second) for the
 AirPlay client to stream video; n must be a whole number less than 256.
 (The client may choose to serve video at any frame rate lower than this;
-default is 30 fps.) A setting below 30 fps might be useful to reduce
+default is 60 fps.) A setting below 60 fps might be useful to reduce
 latency if you are running more than one instance of uxplay at the same
 time. *This setting is only an advisory to the client device, so setting
 a high value will not force a high framerate.* (You can test using "-vs

--- a/README.txt
+++ b/README.txt
@@ -1122,7 +1122,8 @@ other settings are set in `UxPlay/lib/dnssdint.h`.
 1.62 2023-01-14 Added Audio-only mode time offset -ao x to allow user
 synchronization of ALAC audio playing on the server with video, song
 lyrics, etc. playing on the client. x = 5.0 appears to be optimal in
-many cases.
+many cases. Quality fixes: change default fps to 60, cleanup in volume
+changes, some bugfixes.
 
 1.61 2022-12-30 Removed -t option (workaround for an Avahi issue,
 correctly solved by opening network port UDP 5353 in firewall). Remove

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-# UxPlay 1.61: AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix (now also runs on Windows).
+# UxPlay 1.62: AirPlay-Mirror and AirPlay-Audio server for Linux, macOS, and Unix (now also runs on Windows).
 
 ### Now developed at the GitHub site <https://github.com/FDH2/UxPlay> (where all user issues should be posted).
 
@@ -308,7 +308,7 @@ installed)
 
 ## Running UxPlay
 
-### Debian-based systems
+### Installing plugins (Debian-based Linux systems)
 
 Next install the GStreamer plugins that are needed with
 `sudo apt-get install gstreamer1.0-<plugin>`. Values of `<plugin>`
@@ -329,44 +329,7 @@ gst-inspect-1.0 for examining the GStreamer installation. If sound is
 not working, "**alsa**"","**pulseaudio**", or "**pipewire**" plugins may
 need to be installed, depending on how your audio is set up.
 
-**Finally, run uxplay in a terminal window**. On some systems, you can
-toggle into and out of fullscreen mode with F11 or (held-down left
-Alt)+Enter keys. Use Ctrl-C (or close the window) to terminate it when
-done. If the UxPlay server is not seen by the iOS client's drop-down
-"Screen Mirroring" panel, check that your DNS-SD server (usually
-avahi-daemon) is running: do this in a terminal window with
-`systemctl status avahi-daemon`. If this shows the avahi-daemon is not
-running, control it with
-`sudo systemctl [start,stop,enable,disable] avahi-daemon` (or
-avahi-daemon.service). If UxPlay is seen, but the client fails to
-connect when it is selected, there may be a firewall on the server that
-prevents UxPlay from receiving client connection requests unless some
-network ports are opened: if a firewall is active, also open UDP port
-5353 (for mDNS queries) needed by Avahi. See
-[Troubleshooting](#troubleshooting) below for help with this or other
-problems.
-
--   By default, UxPlay is locked to its current client until that client
-    drops the connection; the option `-nohold` modifies this behavior so
-    that when a new client requests a connection, it removes the current
-    client and takes over.
-
-To display the accompanying "Cover Art" from sources like Apple Music in
-Audio-Only (ALAC) mode, run "`uxplay -ca <name> &`" in the background,
-then run a image viewer with an autoreload feature: an example is "feh":
-run "`feh -R 1 <name>`" in the foreground; terminate feh and then Uxplay
-with "`ctrl-C fg ctrl-C`".
-
-**One common problem involves GStreamer attempting to use
-incorrectly-configured or absent accelerated hardware h264 video
-decoding (e.g., VAAPI). Try "`uxplay -avdec`" to force software video
-decoding; if this works you can then try to fix accelerated hardware
-video decoding if you need it, or just uninstall the GStreamer VAAPI
-plugin. If your system uses the Wayland compositor for graphics, use
-"`uxplay -vs waylandsink`".** See [Usage](#usage) for more run-time
-options.
-
-### Running uxplay Non-Debian-based Linux or \*BSD
+### Installing plugins (Non-Debian-based Linux or \*BSD)
 
 -   **Red Hat, or clones like CentOS (now continued as Rocky Linux or
     Alma Linux):** (sudo dnf install, or sudo yum install) The required
@@ -399,6 +362,57 @@ options.
     gstreamer1-plugins, gstreamer1-plugins-\* (\* = core, good, bad, x,
     gtk, gl, vulkan, pulse, v4l2, ...), (+ gstreamer1-vaapi for Intel
     graphics).
+
+### Starting UxPlay
+
+**Finally, run uxplay in a terminal window**. On some systems, you can
+toggle into and out of fullscreen mode with F11 or (held-down left
+Alt)+Enter keys. Use Ctrl-C (or close the window) to terminate it when
+done. If the UxPlay server is not seen by the iOS client's drop-down
+"Screen Mirroring" panel, check that your DNS-SD server (usually
+avahi-daemon) is running: do this in a terminal window with
+`systemctl status avahi-daemon`. If this shows the avahi-daemon is not
+running, control it with
+`sudo systemctl [start,stop,enable,disable] avahi-daemon` (or
+avahi-daemon.service). If UxPlay is seen, but the client fails to
+connect when it is selected, there may be a firewall on the server that
+prevents UxPlay from receiving client connection requests unless some
+network ports are opened: if a firewall is active, also open UDP port
+5353 (for mDNS queries) needed by Avahi. See
+[Troubleshooting](#troubleshooting) below for help with this or other
+problems.
+
+-   By default, UxPlay is locked to its current client until that client
+    drops the connection; the option `-nohold` modifies this behavior so
+    that when a new client requests a connection, it removes the current
+    client and takes over.
+
+-   To display the accompanying "Cover Art" from sources like Apple
+    Music in Audio-Only (ALAC) mode, run "`uxplay -ca <name> &`" in the
+    background, then run a image viewer with an autoreload feature: an
+    example is "feh": run "`feh -R 1 <name>`" in the foreground;
+    terminate feh and then Uxplay with "`ctrl-C fg ctrl-C`".
+
+-   If you wish to listen in Audio-Only mode on the server while
+    watching the client screen (for video or Apple Music song lyrics,
+    etc.), the video on the client is delayed by about 5 seconds behind
+    the the audio on the server. This can be corrected with the **audio
+    offset** option `-ao x` with an *x* of about 5.0 (allowed values of
+    *x* are decimal numbers between 0 and 10.0 seconds); this workaround
+    just delays playing of audio on the server by *x* seconds, so the
+    effect of pausing or changing tracks on the client will
+    unfortunately also be delayed. *(The reason for the 5 sec. video
+    delay on the client may be because, while streaming in Legacy mode,
+    the client does not get latency information from the server.)*
+
+**One common problem involves GStreamer attempting to use
+incorrectly-configured or absent accelerated hardware h264 video
+decoding (e.g., VAAPI). Try "`uxplay -avdec`" to force software video
+decoding; if this works you can then try to fix accelerated hardware
+video decoding if you need it, or just uninstall the GStreamer VAAPI
+plugin. If your system uses the Wayland compositor for graphics, use
+"`uxplay -vs waylandsink`".** See [Usage](#usage) for more run-time
+options.
 
 ### **Special instructions for Raspberry Pi (only tested on model 4B)**:
 
@@ -495,7 +509,7 @@ Next get the latest macOS release of GStreamer-1.0.
 
 **For the "official" release**: install both the macOS runtime and
 development installer packages. Assuming that the latest release is
-1.20.4. install `gstreamer-1.0-1.20.5-universal.pkg` and
+1.20.5. install `gstreamer-1.0-1.20.5-universal.pkg` and
 `gstreamer-1.0-devel-1.20.5-universal.pkg`. (If you have an
 Intel-architecture Mac, and have problems with the "universal" packages,
 you can also use `gstreamer-1.0-1.18.6-x86_64.pkg` and
@@ -775,6 +789,15 @@ name. (Some choices of audiosink might not work on your system.)
 
 **-as 0** (or just **-a**) suppresses playing of streamed audio, but
 displays streamed video.
+
+**-ao x.y** adds an audio offset time in (decimal) seconds to Audio-only
+(ALAC) streams to allow synchronization of sound playing on the UxPlay
+server with video on the client. In the AirPlay Legacy mode used by
+UxPlay, the client cannot obtain audio latency information from the
+server, and appears to assume a latency of about 5 seconds. This can be
+corrected with offset values such as `-ao 5` or `-ao 4.9`. The -ao
+option accepts values of the offset between 0 and 10 seconds, as a
+decimal number which it converts to a whole number of milliseconds.
 
 **-ca *filename*** provides a file (where *filename* can include a full
 path) used for output of "cover art" (from Apple Music, *etc.*,) in
@@ -1094,6 +1117,11 @@ the client by the AirPlay server) to be set. The "features" code and
 other settings are set in `UxPlay/lib/dnssdint.h`.
 
 # Changelog
+
+1.62 2023-01-14 Added Audio-only mode time offset -ao x to allow user
+synchronization of ALAC audio playing on the server with video, song
+lyrics, etc. playing on the client. x = 5.0 appears to be optimal in
+many cases.
 
 1.61 2022-12-30 Removed -t option (workaround for an Avahi issue,
 correctly solved by opening network port UDP 5353 in firewall). Remove

--- a/README.txt
+++ b/README.txt
@@ -373,14 +373,15 @@ done. If the UxPlay server is not seen by the iOS client's drop-down
 avahi-daemon) is running: do this in a terminal window with
 `systemctl status avahi-daemon`. If this shows the avahi-daemon is not
 running, control it with
-`sudo systemctl [start,stop,enable,disable] avahi-daemon` (or
-avahi-daemon.service). If UxPlay is seen, but the client fails to
-connect when it is selected, there may be a firewall on the server that
-prevents UxPlay from receiving client connection requests unless some
-network ports are opened: if a firewall is active, also open UDP port
-5353 (for mDNS queries) needed by Avahi. See
-[Troubleshooting](#troubleshooting) below for help with this or other
-problems.
+`sudo systemctl [start,stop,enable,disable] avahi-daemon` (on
+non-systemd systems, such as \*BSD, use
+`sudo service avahi-daemon [status, start, stop, restart, ...]`). If
+UxPlay is seen, but the client fails to connect when it is selected,
+there may be a firewall on the server that prevents UxPlay from
+receiving client connection requests unless some network ports are
+opened: if a firewall is active, also open UDP port 5353 (for mDNS
+queries) needed by Avahi. See [Troubleshooting](#troubleshooting) below
+for help with this or other problems.
 
 -   By default, UxPlay is locked to its current client until that client
     drops the connection; the option `-nohold` modifies this behavior so

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -454,7 +454,7 @@ raop_init(int max_clients, raop_callbacks_t *callbacks) {
     raop->width = 1920;
     raop->height = 1080;
     raop->refreshRate = 60;
-    raop->maxFPS = 60;
+    raop->maxFPS = 30;
     raop->overscanned = 0;
 
     /* initialize switch for display of client's streaming data records */    

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -454,7 +454,7 @@ raop_init(int max_clients, raop_callbacks_t *callbacks) {
     raop->width = 1920;
     raop->height = 1080;
     raop->refreshRate = 60;
-    raop->maxFPS = 30;
+    raop->maxFPS = 60;
     raop->overscanned = 0;
 
     /* initialize switch for display of client's streaming data records */    

--- a/lib/raop_buffer.c
+++ b/lib/raop_buffer.c
@@ -154,11 +154,11 @@ raop_buffer_decrypt(raop_buffer_t *raop_buffer, unsigned char *data, unsigned ch
 
     if (DECRYPTION_TEST) {
         char *str = utils_data_to_string(data,12,12);
-        printf("encrypted 12 byte header %s", str);
+        logger_log(raop_buffer->logger, LOGGER_INFO, "encrypted 12 byte header %s", str);
         free(str);
         if (payload_size) {
             str = utils_data_to_string(&data[12],16,16);
-            printf("len %d before decryption:\n%s", payload_size, str);
+            logger_log(raop_buffer->logger, LOGGER_INFO, "len %d before decryption:\n%s", payload_size, str);
             free(str);
         }
     }
@@ -181,18 +181,17 @@ raop_buffer_decrypt(raop_buffer_t *raop_buffer, unsigned char *data, unsigned ch
         case 0x20:
 	    break;
         default:
-            printf("***ERROR AUDIO FRAME  IS NOT AAC_ELD OR ALAC\n");
+            logger_log(raop_buffer->logger, LOGGER_INFO, "***ERROR AUDIO FRAME  IS NOT AAC_ELD OR ALAC");
 	    break;
         }
         if (DECRYPTION_TEST == 2) {
-            printf("decrypted audio frame, len = %d\n", *outputlen);
+            logger_log(raop_buffer->logger, LOGGER_INFO, "decrypted audio frame, len = %d", *outputlen);
             char *str = utils_data_to_string(output,payload_size,16);
-	    printf("%s",str);
-            printf("\n");
+            logger_log(raop_buffer->logger, LOGGER_INFO,"%s",str);
             free(str);
         } else {
             char *str = utils_data_to_string(output,16,16);
-            printf("%d after  \n%s\n", payload_size, str);
+            logger_log(raop_buffer->logger, LOGGER_INFO, "%d after  \n%s", payload_size, str);
             free(str);
         }
     }

--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -342,7 +342,7 @@ raop_rtp_process_events(raop_rtp_t *raop_rtp, void *cb_data)
 
     /* Call set_volume callback if changed */
     if (volume_changed) {
-        raop_buffer_flush(raop_rtp->buffer, flush);
+        //raop_buffer_flush(raop_rtp->buffer, flush); /* seems to be unnecessary, may cause audio artefacts */
         if (raop_rtp->callbacks.audio_set_volume) {
             raop_rtp->callbacks.audio_set_volume(raop_rtp->callbacks.cls, volume);
         }

--- a/lib/raop_rtp_mirror.c
+++ b/lib/raop_rtp_mirror.c
@@ -436,7 +436,7 @@ raop_rtp_mirror_thread(void *arg)
 #endif
                 payload_decrypted = NULL;
                 h264_decode_struct h264_data;
-                h264_data.pts = ntp_timestamp;
+                h264_data.ntp_time = ntp_timestamp;
                 h264_data.nal_count = nalus_count;   /*nal_count will be the number of nal units in the packet */
                 h264_data.data_len = payload_size;
                 h264_data.data = payload_out;

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -22,7 +22,7 @@ typedef struct {
     int nal_count;
     unsigned char *data;
     int data_len;
-    uint64_t pts;
+    uint64_t ntp_time;
 } h264_decode_struct;
 
 typedef struct {

--- a/renderers/audio_renderer.h
+++ b/renderers/audio_renderer.h
@@ -27,14 +27,13 @@ extern "C" {
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include "../lib/raop_ntp.h"
+#include "../lib/logger.h"
 
-bool gstreamer_init();
+bool gstreamer_init(uint64_t * unix_start_time, uint64_t *monotonic_start_time);
 void audio_renderer_init(logger_t *logger, const char* audiosink, const char* audiodelay);
 void audio_renderer_start(unsigned char* compression_type);
 void audio_renderer_stop();
-void audio_renderer_render_buffer(raop_ntp_t *ntp, unsigned char* data, int data_len,
-                                  uint64_t ntp_time, uint64_t rtp_time, unsigned short seqnum);
+void audio_renderer_render_buffer(unsigned char* data, int *data_len, unsigned short *seqnum, uint64_t *pts);
 void audio_renderer_set_volume(float volume);
 void audio_renderer_flush();
 void audio_renderer_destroy();

--- a/renderers/audio_renderer.h
+++ b/renderers/audio_renderer.h
@@ -30,7 +30,7 @@ extern "C" {
 #include "../lib/raop_ntp.h"
 
 bool gstreamer_init();
-void audio_renderer_init(logger_t *logger, const char* audiosink);
+void audio_renderer_init(logger_t *logger, const char* audiosink, const char* audiodelay);
 void audio_renderer_start(unsigned char* compression_type);
 void audio_renderer_stop();
 void audio_renderer_render_buffer(raop_ntp_t *ntp, unsigned char* data, int data_len,

--- a/renderers/audio_renderer_gstreamer.c
+++ b/renderers/audio_renderer_gstreamer.c
@@ -203,9 +203,10 @@ void audio_renderer_render_buffer(raop_ntp_t *ntp, unsigned char* data, int data
      *                   but is 0x80, 0x81 or 0x82: 0x100000(00,01,10) in ios9, ios10 devices          *
      * first byte of AAC_LC should be 0xff (ADTS) (but has never been  seen).                          */
     
-    buffer = gst_buffer_new_and_alloc(data_len);
+    buffer = gst_buffer_new_allocate(NULL, data_len, NULL);
     g_assert(buffer != NULL);
-    GST_BUFFER_PTS(buffer) = (GstClockTime) ntp_time;
+    /* ntp_time is PTS given as UTC in usec */
+    GST_BUFFER_PTS(buffer) = (GstClockTime) (ntp_time * 1000);
     gst_buffer_fill(buffer, 0, data, data_len);
     switch (renderer->ct){
     case 8: /*AAC-ELD*/

--- a/renderers/video_renderer.h
+++ b/renderers/video_renderer.h
@@ -32,7 +32,6 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 #include "../lib/logger.h"
-#include "../lib/raop_ntp.h"
 
 typedef enum videoflip_e {
     NONE,
@@ -49,7 +48,7 @@ void video_renderer_init (logger_t *logger, const char *server_name, videoflip_t
                           const char *decoder, const char *converter, const char *videosink, const bool *fullscreen);
 void video_renderer_start ();
 void video_renderer_stop ();
-void video_renderer_render_buffer (raop_ntp_t *ntp, unsigned char* data, int data_len, uint64_t ntp_time, int nal_count);
+void video_renderer_render_buffer (unsigned char* data, int *data_len, int *nal_count, uint64_t *pts);
 void video_renderer_flush ();
 unsigned int video_renderer_listen(void *loop);
 void video_renderer_destroy ();

--- a/renderers/video_renderer.h
+++ b/renderers/video_renderer.h
@@ -49,7 +49,7 @@ void video_renderer_init (logger_t *logger, const char *server_name, videoflip_t
                           const char *decoder, const char *converter, const char *videosink, const bool *fullscreen);
 void video_renderer_start ();
 void video_renderer_stop ();
-void video_renderer_render_buffer (raop_ntp_t *ntp, unsigned char* data, int data_len, uint64_t pts, int nal_count);
+void video_renderer_render_buffer (raop_ntp_t *ntp, unsigned char* data, int data_len, uint64_t ntp_time, int nal_count);
 void video_renderer_flush ();
 unsigned int video_renderer_listen(void *loop);
 void video_renderer_destroy ();

--- a/uxplay.1
+++ b/uxplay.1
@@ -85,7 +85,7 @@ UxPlay 1.62: An open\-source AirPlay mirroring (+ audio streaming) server.
 .TP
 \fB\-FPSdata\fR  Show video-streaming performance reports sent by client.
 .TP
-\fB\-fps\fR n    Set maximum allowed streaming framerate, default 30
+\fB\-fps\fR n    Set maximum allowed streaming framerate, default 60
 .TP
 \fB\-f\fR {H|V|I}Horizontal|Vertical flip, or both=Inversion=rotate 180 deg
 .TP

--- a/uxplay.1
+++ b/uxplay.1
@@ -85,7 +85,7 @@ UxPlay 1.62: An open\-source AirPlay mirroring (+ audio streaming) server.
 .TP
 \fB\-FPSdata\fR  Show video-streaming performance reports sent by client.
 .TP
-\fB\-fps\fR n    Set maximum allowed streaming framerate, default 60
+\fB\-fps\fR n    Set maximum allowed streaming framerate, default 30
 .TP
 \fB\-f\fR {H|V|I}Horizontal|Vertical flip, or both=Inversion=rotate 180 deg
 .TP

--- a/uxplay.1
+++ b/uxplay.1
@@ -1,11 +1,11 @@
-.TH UXPLAY "1" "December 2022" "1.61" "User Commands"
+.TH UXPLAY "1" "January 2023" "1.62" "User Commands"
 .SH NAME
 uxplay \- start AirPlay server
 .SH SYNOPSIS
 .B uxplay
 [\fI\,-n name\/\fR] [\fI\,-s wxh\/\fR] [\fI\,-p \/\fR[\fI\,n\/\fR]] [more \fI OPTIONS \/\fR ...]
 .SH DESCRIPTION
-UxPlay 1.61: An open\-source AirPlay mirroring (+ audio streaming) server.
+UxPlay 1.62: An open\-source AirPlay mirroring (+ audio streaming) server.
 .SH OPTIONS
 .TP
 .B
@@ -72,6 +72,8 @@ UxPlay 1.61: An open\-source AirPlay mirroring (+ audio streaming) server.
 .PP
 .TP
 \fB\-as\fR 0     (or \fB\-a\fR) Turn audio off, streamed video only.
+.TP
+\fB\-ao\fR x.y   Audio offset time in seconds (default 0.0) in Audio-only mode.
 .TP
 \fB\-ca\fI fn \fR   In Airplay Audio (ALAC) mode, write cover-art to file fn.
 .TP

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -73,6 +73,7 @@ static videoflip_t videoflip[2] = { NONE , NONE };
 static bool use_video = true;
 static unsigned char compression_type = 0;
 static std::string audiosink = "autoaudiosink";
+static std::string audiodelay = "";
 static bool use_audio = true;
 static bool new_window_closing_behavior = true;
 static bool close_window;
@@ -735,6 +736,19 @@ static void parse_arguments (int argc, char *argv[]) {
             bt709_fix = true;
         } else if (arg == "-nohold") {
             max_connections = 3;
+        } else if (arg == "-ad") {
+            if (i < argc - 1 && *argv[i+1] != '-') {
+                unsigned int n = 0;
+                if (get_value (argv[++i], &n)) {
+                    audiodelay.erase();
+                    if (n > 0) {
+                        audiodelay = argv[i];
+                    }
+                }
+            } else {
+                LOGE("option -ad must be followed by a positive time delay in millisecs");
+                exit(1);
+            }
         } else {
             LOGE("unknown option %s, stopping\n",argv[i]);
             exit(1);
@@ -1259,7 +1273,10 @@ int main (int argc, char *argv[]) {
     logger_set_level(render_logger, debug_log ? LOGGER_DEBUG : LOGGER_INFO);
 
     if (use_audio) {
-        audio_renderer_init(render_logger, audiosink.c_str());
+        if (audiodelay.c_str()[0]) {
+            LOGI("Audio-only ALAC streams will be delayed by %s millisecs", audiodelay.c_str());
+        }
+        audio_renderer_init(render_logger, audiosink.c_str(), audiodelay.c_str());
     } else {
         LOGI("audio_disabled");
     }

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -999,7 +999,7 @@ extern "C" void video_process (void *cls, raop_ntp_t *ntp, h264_decode_struct *d
         dump_video_to_file(data->data, data->data_len);
     }
     if (use_video) {
-        video_renderer_render_buffer(ntp, data->data, data->data_len, data->pts, data->nal_count);
+        video_renderer_render_buffer(ntp, data->data, data->data_len, data->ntp_time, data->nal_count);
     }
 }
 

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -765,7 +765,7 @@ static void process_metadata(int count, const char *dmap_tag, const unsigned cha
         printf("%d: dmap_tag [%s], %d\n", count, dmap_tag, datalen);
     }
 
-    /* String-type DMAP tags seen in Apple Music Radio are processed here.   *
+    /* UTF-8 String-type DMAP tags seen in Apple Music Radio are processed here.   *
      * (DMAP tags "asal", "asar", "ascp", "asgn", "minm" ). TODO expand this */  
     
     if (datalen == 0) {
@@ -842,6 +842,10 @@ static void process_metadata(int count, const char *dmap_tag, const unsigned cha
                 printf("Format: ");
             } else if (strcmp (dmap_tag, "asgn") == 0) {
                 printf("Genre: ");
+            } else if (strcmp (dmap_tag, "asky") == 0) {
+                printf("Keywords: ");
+            } else if (strcmp (dmap_tag, "aslc") == 0) {
+                printf("Long Content Description: ");
             } else {
                 dmap_type = 0;
             }

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -393,7 +393,7 @@ static void print_info (char *name) {
     printf("-nc       do Not Close video window when client stops mirroring\n");
     printf("-nohold   Drop current connection when new client connects.\n");
     printf("-FPSdata  Show video-streaming performance reports sent by client.\n");
-    printf("-fps n    Set maximum allowed streaming framerate, default 30\n");
+    printf("-fps n    Set maximum allowed streaming framerate, default 60\n");
     printf("-f {H|V|I}Horizontal|Vertical flip, or both=Inversion=rotate 180 deg\n");
     printf("-r {R|L}  Rotate 90 degrees Right (cw) or Left (ccw)\n");
     printf("-m        Use random MAC address (use for concurrent UxPlay's)\n");

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -394,7 +394,7 @@ static void print_info (char *name) {
     printf("-nc       do Not Close video window when client stops mirroring\n");
     printf("-nohold   Drop current connection when new client connects.\n");
     printf("-FPSdata  Show video-streaming performance reports sent by client.\n");
-    printf("-fps n    Set maximum allowed streaming framerate, default 60\n");
+    printf("-fps n    Set maximum allowed streaming framerate, default 30\n");
     printf("-f {H|V|I}Horizontal|Vertical flip, or both=Inversion=rotate 180 deg\n");
     printf("-r {R|L}  Rotate 90 degrees Right (cw) or Left (ccw)\n");
     printf("-m        Use random MAC address (use for concurrent UxPlay's)\n");

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -542,7 +542,7 @@ static void append_hostname(std::string &server_name) {
 #endif
 }
 
-static void parse_arguments (int argc, char *argv[]) {    
+static void parse_arguments (int argc, char *argv[]) {
     // Parse arguments
     for (int i = 1; i < argc; i++) {
         std::string arg(argv[i]);
@@ -647,14 +647,14 @@ static void parse_arguments (int argc, char *argv[]) {
             video_converter = "videoconvert";
         } else if (arg == "-v4l2" || arg == "-rpi") {
             if (arg == "-rpi") {
-                printf("*** -rpi no longer includes -bt709: add it if needed\n");
+                LOGI("*** -rpi no longer includes -bt709: add it if needed");
             }
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();
             video_converter = "v4l2convert";
         } else if (arg == "-rpifb") {
-            printf("*** -rpifb no longer includes -bt709: add it if needed\n");
+            LOGI("*** -rpifb no longer includes -bt709: add it if needed");
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();
@@ -662,7 +662,7 @@ static void parse_arguments (int argc, char *argv[]) {
             videosink.erase();
             videosink = "kmssink";
         } else if (arg == "-rpigl") {
-            printf("*** -rpigl does not include -bt709: add it if needed\n");
+            LOGI("*** -rpigl does not include -bt709: add it if needed");
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();
@@ -670,7 +670,7 @@ static void parse_arguments (int argc, char *argv[]) {
             videosink.erase();
             videosink = "glimagesink";
         } else if (arg == "-rpiwl" ) {
-            printf("*** -rpiwl no longer includes -bt709: add it if needed\n");
+            LOGI("*** -rpiwl no longer includes -bt709: add it if needed");
             video_decoder.erase();
             video_decoder = "v4l2h264dec";
             video_converter.erase();
@@ -730,7 +730,7 @@ static void parse_arguments (int argc, char *argv[]) {
                 coverart_filename.erase();
                 coverart_filename.append(argv[++i]);
             } else {
-                LOGE("option -ca must be followed by a filename for cover-art output");
+                fprintf(stderr,"option -ca must be followed by a filename for cover-art output\n");
                 exit(1);
             }
         } else if (arg == "-bt709") {
@@ -753,11 +753,11 @@ static void parse_arguments (int argc, char *argv[]) {
                     continue;
                 }
             }
-            LOGE("invalid argument -ao %s: must be a decimal time offset in seconds, range [0,10]\n"
-                 "(like 5 or 4.8, which will be converted to a whole number of milliseconds)", argv[i]);
+            fprintf(stderr, "invalid argument -ao %s: must be a decimal time offset in seconds, range [0,10]\n"
+                    "(like 5 or 4.8, which will be converted to a whole number of milliseconds)\n", argv[i]);
             exit(1);
 	} else {
-            LOGE("unknown option %s, stopping\n",argv[i]);
+            fprintf(stderr, "unknown option %s, stopping\n",argv[i]);
             exit(1);
         }
     }


### PR DESCRIPTION
1.62 2023-01-22 Added Audio-only mode time offset -ao x to allow user synchronization in Audio-only mode of audio playing on the server with video, song lyrics, etc. playing on the client. x = 5.0 appears to be optimal in many cases. Quality fixes: cleanup in volume changes, timestamps, some bugfixes.